### PR TITLE
Add E_DEVICERESET handle in AnimationSet2D and AnimatedSprite2D

### DIFF
--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.h
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.h
@@ -132,6 +132,7 @@ protected:
     void UpdateSpriterAnimation(float timeStep);
     /// Update vertices for spriter animation.
     void UpdateSourceBatchesSpriter();
+    void HandleDeviceReset(StringHash eventType, VariantMap& eventData);
     /// Dispose.
     void Dispose();
 

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.h
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.h
@@ -132,6 +132,7 @@ protected:
     void UpdateSpriterAnimation(float timeStep);
     /// Update vertices for spriter animation.
     void UpdateSourceBatchesSpriter();
+    /// Reload sprite and spriter data on device reset.
     void HandleDeviceReset(StringHash eventType, VariantMap& eventData);
     /// Dispose.
     void Dispose();

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -393,9 +393,10 @@ bool AnimationSet2D::EndLoadSpriter()
                 unsigned key = folder->id_ << 16u | file->id_;
                 spriterFileSprites_[key] = sprite;
 
-                UnsubscribeFromEvent(E_DEVICERESET);
             }
         }
+
+        UnsubscribeFromEvent(E_DEVICERESET);
     }
     else
     {

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -515,9 +515,12 @@ void AnimationSet2D::HandleDeviceReset(StringHash eventType, VariantMap& eventDa
 {
     auto* cache = GetSubsystem<ResourceCache>();
 
-    bool reloadResult = cache->ReloadResource(this);
+    bool success = false;
+    SharedPtr<File> file = cache->GetFile(GetName());
+    if (file)
+        success = Load(*(file.Get()));
 
-    if (!reloadResult)
+    if (!success)
     {
         URHO3D_LOGERROR("AnimationSet2D reload on device reset failed!");
     }

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -25,6 +25,7 @@
 #include "../Container/ArrayPtr.h"
 #include "../Core/Context.h"
 #include "../Graphics/Graphics.h"
+#include "../Graphics/GraphicsEvents.h"
 #include "../Graphics/Texture2D.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
@@ -391,6 +392,8 @@ bool AnimationSet2D::EndLoadSpriter()
 
                 unsigned key = folder->id_ << 16u | file->id_;
                 spriterFileSprites_[key] = sprite;
+
+                UnsubscribeFromEvent(E_DEVICERESET);
             }
         }
     }
@@ -500,9 +503,23 @@ bool AnimationSet2D::EndLoadSpriter()
             unsigned key = info.file_->folder_->id_ << 16u | info.file_->id_;
             spriterFileSprites_[key] = sprite_;
         }
+
+        SubscribeToEvent(E_DEVICERESET, URHO3D_HANDLER(AnimationSet2D, HandleDeviceReset));
     }
 
     return true;
+}
+
+void AnimationSet2D::HandleDeviceReset(StringHash eventType, VariantMap& eventData)
+{
+    auto* cache = GetSubsystem<ResourceCache>();
+
+    bool reloadResult = cache->ReloadResource(this);
+
+    if (!reloadResult)
+    {
+        URHO3D_LOGERROR("AnimationSet2D reload on device reset failed!");
+    }
 }
 
 void AnimationSet2D::Dispose()

--- a/Source/Urho3D/Urho2D/AnimationSet2D.h
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.h
@@ -81,6 +81,8 @@ public:
     Spriter::SpriterData* GetSpriterData() const { return spriterData_.Get(); }
     /// Return spriter file sprite.
     Sprite2D* GetSpriterFileSprite(int folderId, int fileId) const;
+    /// True if a spritesheet xml file was found during the loading of this animationSet
+    bool HasSpriteSheet() const { return hasSpriteSheet_; }
 
 private:
     /// Return sprite by hash.
@@ -95,6 +97,7 @@ private:
     bool BeginLoadSpriter(Deserializer& source);
     /// Finish load scml.
     bool EndLoadSpriter();
+    void HandleDeviceReset(StringHash eventType, VariantMap& eventData);
     /// Dispose all data.
     void Dispose();
 

--- a/Source/Urho3D/Urho2D/AnimationSet2D.h
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.h
@@ -97,6 +97,7 @@ private:
     bool BeginLoadSpriter(Deserializer& source);
     /// Finish load scml.
     bool EndLoadSpriter();
+    /// Reload the animationSet on device reset.
     void HandleDeviceReset(StringHash eventType, VariantMap& eventData);
     /// Dispose all data.
     void Dispose();


### PR DESCRIPTION
This should fix some AnimatedSprite2Ds breaking on openGL context lost. (issue #35)

I've tested demos 33, 49 and 50 on windows desktop, and fullscreen toggling seems to be fine now. Tested sample 49 in a web build and the sprites also didn't disappear.

I've added a "HasSpriteSheet" method to AnimatedSprite2D, to be able to only subscribe to E_DEVICERESET where it's really needed. AnimatedSprite2D needs to know about the reset in order to point to the rebuilt animationSet data.

I'm not a C++ guy, so I'm not sure if I did things the right way or forgot to clean up something. Maybe there's a better approach for reloading?