### PR TITLE
Always include Texture2D.h in Graphics.cpp

### DIFF
--- a/Source/Urho3D/Graphics/Graphics.cpp
+++ b/Source/Urho3D/Graphics/Graphics.cpp
@@ -45,9 +45,7 @@
 #include "../Graphics/Technique.h"
 #include "../Graphics/Terrain.h"
 #include "../Graphics/TerrainPatch.h"
-#ifdef _WIN32
 #include "../Graphics/Texture2D.h"
-#endif
 #include "../Graphics/Texture2DArray.h"
 #include "../Graphics/Texture3D.h"
 #include "../Graphics/TextureCube.h"


### PR DESCRIPTION
Commit 6d08bcd added an `#ifdef _WIN32` around the `#include "../Graphics/Texture2D.h"` for no apparent reason. This caused an incomplete type error where Texture2D is registered when I was testing the [Diligent backend](https://github.com/cosator/U3D_Diligent).