### PR TITLE
Fix for EditorResourceBrowser not showing resource types

### DIFF
--- a/bin/Data/Scripts/Editor/EditorResourceBrowser.as
+++ b/bin/Data/Scripts/Editor/EditorResourceBrowser.as
@@ -1073,8 +1073,15 @@ int GetResourceType(String path)
 
 int GetResourceType(String path, StringHash &out fileType, bool useCache = false)
 {
-    if (GetExtensionType(path, fileType) || GetBinaryType(path, fileType, useCache) || GetXmlType(path, fileType, useCache))
+    if(GetExtensionType(path, fileType)){
         return GetResourceType(fileType);
+    }
+    else if(GetBinaryType(path, fileType, useCache)){
+        return GetResourceType(fileType);
+    }
+    else if(GetXmlType(path, fileType, useCache)){
+        return GetResourceType(fileType);
+    }
 
     return RESOURCE_TYPE_UNKNOWN;
 }


### PR DESCRIPTION
Apparently, only the first "get" in the chain of conditions was setting and keeping the value of the fileType variable, so only some of the resources were being shown correctly. If we changed the order of conditions and, for example, put GetBinaryType before GetExtensionType, then another group of resources would display correctly, and the previous one would break. 
Separating the checks in if statements seems to fix the issue, making all 3 groups show their types correctly. 

I think this is related to the angelscript update, since I don't remember having this issue in base Urho