### PR TITLE
Do not delete String::endZero

### DIFF
--- a/Source/Urho3D/Container/Str.h
+++ b/Source/Urho3D/Container/Str.h
@@ -165,7 +165,7 @@ public:
     /// Destruct.
     ~String()
     {
-        if (capacity_)
+        if (capacity_ && buffer_ != &endZero)
             delete[] buffer_;
     }
 


### PR DESCRIPTION
```
[ 59%] Building CXX object Source/Urho3D/CMakeFiles/Urho3D.dir/Container/Str.cpp.o
In file included from U3D/Source/Urho3D/Precompiled.h:31:
In destructor ‘Urho3D::String::~String()’,
    inlined from ‘Urho3D::String Urho3D::String::Substring(unsigned int) const’ at U3D/Source/Urho3D/Container/Str.cpp:499:5:
U3D/Source/Urho3D/Container/Str.h:169:22: warning: ‘void operator delete [](void*)’ called on unallocated object ‘Urho3D::String::endZero’ [-Wfree-nonheap-object]
  169 |             delete[] buffer_;
      |                      ^~~~~~~
U3D/Source/Urho3D/Container/Str.cpp: In member function ‘Urho3D::String Urho3D::String::Substring(unsigned int) const’:
U3D/Source/Urho3D/Container/Str.cpp:38:6: note: declared here
   38 | char String::endZero = 0;
      |      ^~~~~~
```