### PR TITLE
Fix web gamepads

### DIFF
--- a/Source/Urho3D/Input/Input.cpp
+++ b/Source/Urho3D/Input/Input.cpp
@@ -409,7 +409,6 @@ void Input::Update()
 
     URHO3D_PROFILE(UpdateInput);
 
-#ifndef __EMSCRIPTEN__
     bool mouseMoved = false;
     if (mouseMove_ != IntVector2::ZERO)
         mouseMoved = true;
@@ -420,6 +419,7 @@ void Input::Update()
     while (SDL_PollEvent(&evt))
         HandleSDLEvent(&evt);
 
+#ifndef __EMSCRIPTEN__
     if (suppressNextMouseMove_ && (mouseMove_ != IntVector2::ZERO || mouseMoved))
         UnsuppressMouseMove();
 #endif


### PR DESCRIPTION
- Fix gamepads not updating on web
- Fix crash on web debug build from `Input::graphics_` being null during the first `SDL_WINDOWEVENT`