### PR TITLE
Fix wordwrap text layout spaces on load

### DIFF
--- a/Source/Urho3D/UI/Text.cpp
+++ b/Source/Urho3D/UI/Text.cpp
@@ -513,6 +513,18 @@ void Text::UpdateText(bool onResize)
         else
         {
             int maxWidth = GetWidth();
+
+            if (!IsFixedWidth())
+            {
+                // use parent layout to set our max width if possible
+                UIElement* parent = GetParent();
+                if (parent && parent->GetLayoutMode() != LM_FREE)
+                {
+                    auto& parentBorder = parent->GetLayoutBorder();
+                    maxWidth = parent->GetWidth() - (parentBorder.left_ + parentBorder.right_);
+                }
+            }
+            
             unsigned nextBreak = 0;
             unsigned lineStart = 0;
             printToText_.Clear();
@@ -648,10 +660,20 @@ void Text::UpdateText(bool onResize)
         // Set minimum and current size according to the text size, but respect fixed width if set
         if (!IsFixedWidth())
         {
-            if (wordWrap_)
-                SetMinWidth(0);
-            else
-            {
+            if (wordWrap_) {
+                // don't set min width to 0 if we're inside a layout
+                UIElement* parent = GetParent();
+                if (parent && parent->GetLayoutMode() != LM_FREE)
+                {
+                    SetMinWidth(width);
+                    SetWidth(width);
+                }
+                else
+                {
+                    SetMinWidth(0);
+                }
+            }
+            else {
                 SetMinWidth(width);
                 SetWidth(width);
             }


### PR DESCRIPTION
This is a possible fix for #61 - the spaces created when loading a UI do not appear with this change. It doesn't do anything with texts outside layouts.