### PR TITLE
Add support for animeted tiles in tmx files

### DIFF
--- a/Source/Urho3D/LuaScript/pkgs/Urho2D/TileMapDefs2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Urho2D/TileMapDefs2D.pkg
@@ -23,6 +23,12 @@ struct TileMapInfo2D
     tolua_readonly tolua_property__get_set float mapHeight;
 };
 
+struct TileFrameInfo2D
+{
+    unsigned gid_ @ gid;
+    unsigned duration_ @ duration;
+};
+
 enum TileMapLayerType2D
 {
     LT_TILE_LAYER,
@@ -47,6 +53,13 @@ class PropertySet2D
     const String GetProperty(const String name) const;
 };
 
+class FrameSet2D
+{
+    void UpdateTimer(float timeStep);
+    unsigned GetCurrentFrameGid() const;
+    unsigned GetNumFrames() const;
+};
+
 static const unsigned FLIP_HORIZONTAL;
 static const unsigned FLIP_VERTICAL;
 static const unsigned FLIP_DIAGONAL;
@@ -62,6 +75,7 @@ class Tile2D
     Sprite2D* GetSprite() const;
     bool HasProperty(const String name) const;
     const String GetProperty(const String name) const;
+    bool IsAnimated() const;
 
     tolua_readonly tolua_property__get_set unsigned gid;
     tolua_readonly tolua_property__get_set Sprite2D* sprite;

--- a/Source/Urho3D/LuaScript/pkgs/Urho2D/TileMapLayer2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Urho2D/TileMapLayer2D.pkg
@@ -5,6 +5,8 @@ class TileMapLayer2D : Component
     void SetDrawOrder(int drawOrder);
     void SetVisible(bool visible);
 
+    void UpdateAnimations();
+
     int GetDrawOrder() const;
     bool IsVisible() const;
     bool HasProperty(const String name) const;

--- a/Source/Urho3D/LuaScript/pkgs/Urho2D/TmxFile2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Urho2D/TmxFile2D.pkg
@@ -1,11 +1,52 @@
 $#include "Urho2D/TmxFile2D.h"
 
-// FIXME: complete the bindings for the rest of the class methods
+class TmxLayer2D
+{
+    TmxFile2D* GetTmxFile() const;
+    TileMapLayerType2D GetType() const;
+    const String GetName() const;
+    int GetWidth() const;
+    int GetHeight() const;
+    bool IsVisible() const;
+    bool HasProperty(const String name) const;
+    const String GetProperty(const String name) const;
+}
+
+class TmxTileLayer2D : TmxLayer2D
+{
+    Tile2D* GetTile(int x, int y) const;
+}
+
+class TmxObjectGroup2D : TmxLayer2D
+{
+    unsigned GetNumObjects() const;
+    TileMapObject2D* GetObject(unsigned index) const;
+}
+
+class TmxImageLayer2D : TmxLayer2D
+{
+    const Vector2 GetPosition() const;
+    const String GetSource() const;
+    Sprite2D* GetSprite() const;
+}
+
 class TmxFile2D : Resource
 {
-    void SetSpriteTextureEdgeOffset(float offset);
+    bool SetInfo(Orientation2D orientation, int width, int height, float tileWidth, float tileHeight);
+    void AddLayer(unsigned index, TmxLayer2D *layer);
+    void AddLayer(TmxLayer2D* layer);
+    const TileMapInfo2D GetInfo() const;
+    Sprite2D* GetTileSprite(unsigned gid) const;
 
+    PropertySet2D* GetTilePropertySet(unsigned gid) const;
+    FrameSet2D* GetTileFrameSet(unsigned gid) const;
+
+    void UpdateAnimationTimers(float timeStep);
+    unsigned GetNumLayers() const;
+    const TmxLayer2D* GetLayer(unsigned index) const;
+    void SetSpriteTextureEdgeOffset(float offset);
     float GetSpriteTextureEdgeOffset() const;
 
+    tolua_readonly tolua_property__get_set TileMapInfo2D info;
     tolua_property__get_set float spriteTextureEdgeOffset @ edgeOffset;
 };

--- a/Source/Urho3D/Urho2D/TileMap2D.h
+++ b/Source/Urho3D/Urho2D/TileMap2D.h
@@ -45,6 +45,9 @@ public:
     /// @nobind
     static void RegisterObject(Context* context);
 
+    /// Handle node being assigned.
+    void OnNodeSet(Node* node) override;
+
     /// Visualize the component as debug geometry.
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
@@ -79,6 +82,11 @@ public:
     ResourceRef GetTmxFileAttr() const;
     ///
     Vector<SharedPtr<TileMapObject2D> > GetTileCollisionShapes(unsigned gid) const;
+
+private:
+    /// Handle scene update.
+    void HandleSceneUpdate(StringHash eventType, VariantMap& eventData);
+
 private:
     /// Tmx file.
     SharedPtr<TmxFile2D> tmxFile_;

--- a/Source/Urho3D/Urho2D/TileMapDefs2D.h
+++ b/Source/Urho3D/Urho2D/TileMapDefs2D.h
@@ -74,6 +74,14 @@ struct URHO3D_API TileMapInfo2D
     bool PositionToTileIndex(int& x, int& y, const Vector2& position) const;
 };
 
+struct URHO3D_API TileFrameInfo2D : public RefCounted
+{
+    /// Gid;
+    unsigned gid_;
+    /// Duration.
+    unsigned duration_;
+};
+
 /// Tile map layer type.
 enum TileMapLayerType2D
 {
@@ -123,6 +131,31 @@ protected:
     HashMap<String, String> nameToValueMapping_;
 };
 
+/// Frame set.
+class URHO3D_API FrameSet2D : public RefCounted
+{
+public:
+    FrameSet2D();
+    ~FrameSet2D() override;
+
+    /// Load from XML element.
+    void Load(const XMLElement& element);
+    /// Update animation timer.
+    void UpdateTimer(float timeStep);
+    /// Get current tile gid of the animation.
+    unsigned GetCurrentFrameGid() const;
+    /// Get number of frames.
+    unsigned GetNumFrames() const;
+
+protected:
+    /// Animation frame infos.
+    Vector<SharedPtr<TileFrameInfo2D> > frames_;
+    /// Time elapsed in the animation (circular timer).
+    float timeElapsed_{0.0f};
+    /// Time it takes to complete one animation.
+    unsigned lapTime_{0};
+};
+
 /// Tile flipping flags.
 static const unsigned FLIP_HORIZONTAL = 0x80000000u;
 static const unsigned FLIP_VERTICAL   = 0x40000000u;
@@ -157,6 +190,8 @@ public:
     bool HasProperty(const String& name) const;
     /// Return property.
     const String& GetProperty(const String& name) const;
+    /// Checks if tile has animation frames.
+    bool IsAnimated() const;
 
 private:
     friend class TmxTileLayer2D;
@@ -167,6 +202,8 @@ private:
     SharedPtr<Sprite2D> sprite_;
     /// Property set.
     SharedPtr<PropertySet2D> propertySet_;
+    /// Frame set.
+    SharedPtr<FrameSet2D> frameSet_;
 };
 
 /// Tile map object.

--- a/Source/Urho3D/Urho2D/TileMapLayer2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMapLayer2D.cpp
@@ -246,6 +246,40 @@ void TileMapLayer2D::SetVisible(bool visible)
     }
 }
 
+void TileMapLayer2D::UpdateAnimations()
+{
+    if (GetLayerType() != LT_TILE_LAYER)
+        return;
+
+    TmxFile2D* tmxFile = GetTileMap()->GetTmxFile();
+    for (int y = 0; y < GetHeight(); y++)
+    {
+        for (int x = 0; x < GetWidth(); x++)
+        {
+            Tile2D* tile = GetTile(x, y);
+            if (!tile)
+                continue;
+
+            if (tile->IsAnimated())
+            {
+                Node* node = GetTileNode(x, y);
+                if (node)
+                {
+                    unsigned curGid = tile->GetGid();
+                    FrameSet2D* frameSet = tmxFile->GetTileFrameSet(curGid);
+                    unsigned newGid = frameSet->GetCurrentFrameGid();
+                    if (curGid != newGid)
+                    {
+                        Sprite2D* sprite = tmxFile->GetTileSprite(newGid);
+                        auto* spriteComponent = node->GetComponent<StaticSprite2D>();
+                        spriteComponent->SetSprite(sprite);
+                    }
+                }
+            }
+        }
+    }
+}
+
 TileMap2D* TileMapLayer2D::GetTileMap() const
 {
     return tileMap_;

--- a/Source/Urho3D/Urho2D/TileMapLayer2D.h
+++ b/Source/Urho3D/Urho2D/TileMapLayer2D.h
@@ -66,6 +66,9 @@ public:
     /// @property
     void SetVisible(bool visible);
 
+    /// For tile layers, update animated tile sprites.
+    void UpdateAnimations();
+
     /// Return tile map.
     TileMap2D* GetTileMap() const;
 

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -149,6 +149,7 @@ bool TmxTileLayer2D::Load(const XMLElement& element, const TileMapInfo2D& info)
                     tile->gid_ = gid;
                     tile->sprite_ = tmxFile_->GetTileSprite(gid & ~FLIP_ALL);
                     tile->propertySet_ = tmxFile_->GetTilePropertySet(gid & ~FLIP_ALL);
+                    tile->frameSet_ = tmxFile_->GetTileFrameSet(gid & ~FLIP_ALL);
                     tiles_[y * width_ + x] = tile;
                 }
 
@@ -173,6 +174,7 @@ bool TmxTileLayer2D::Load(const XMLElement& element, const TileMapInfo2D& info)
                     tile->gid_ = gid;
                     tile->sprite_ = tmxFile_->GetTileSprite(gid & ~FLIP_ALL);
                     tile->propertySet_ = tmxFile_->GetTilePropertySet(gid & ~FLIP_ALL);
+                    tile->frameSet_ = tmxFile_->GetTileFrameSet(gid & ~FLIP_ALL);
                     tiles_[y * width_ + x] = tile;
                 }
                 ++currentIndex;
@@ -203,6 +205,7 @@ bool TmxTileLayer2D::Load(const XMLElement& element, const TileMapInfo2D& info)
                     tile->gid_ = gid;
                     tile->sprite_ = tmxFile_->GetTileSprite(gid & ~FLIP_ALL);
                     tile->propertySet_ = tmxFile_->GetTilePropertySet(gid & ~FLIP_ALL);
+                    tile->frameSet_ = tmxFile_->GetTileFrameSet(gid & ~FLIP_ALL);
                     tiles_[y * width_ + x] = tile;
                 }
                 currentIndex += 4;
@@ -579,6 +582,22 @@ PropertySet2D* TmxFile2D::GetTilePropertySet(unsigned gid) const
     return i->second_;
 }
 
+FrameSet2D* TmxFile2D::GetTileFrameSet(unsigned gid) const
+{
+    HashMap<unsigned, SharedPtr<FrameSet2D> >::ConstIterator i = gidToFrameSetMapping_.Find(gid);
+    if (i == gidToFrameSetMapping_.End())
+        return nullptr;
+    return i->second_;
+}
+
+void TmxFile2D::UpdateAnimationTimers(float timeStep)
+{
+    for (auto i = gidToFrameSetMapping_.Begin(); i != gidToFrameSetMapping_.End(); ++i)
+    {
+        i->second_->UpdateTimer(timeStep);
+    }
+}
+
 const TmxLayer2D* TmxFile2D::GetLayer(unsigned index) const
 {
     if (index >= layers_.Size())
@@ -737,6 +756,12 @@ bool TmxFile2D::LoadTileSet(const XMLElement& element)
             SharedPtr<PropertySet2D> propertySet(new PropertySet2D());
             propertySet->Load(tileElem.GetChild("properties"));
             gidToPropertySetMapping_[gid] = propertySet;
+        }
+        if (tileElem.HasChild("animation"))
+        {
+            SharedPtr<FrameSet2D> frameSet(new FrameSet2D());
+            frameSet->Load(tileElem.GetChild("animation"));
+            gidToFrameSetMapping_[gid] = frameSet;
         }
     }
 

--- a/Source/Urho3D/Urho2D/TmxFile2D.h
+++ b/Source/Urho3D/Urho2D/TmxFile2D.h
@@ -193,6 +193,12 @@ public:
     /// Return tile property set by gid, if not exist return 0.
     PropertySet2D* GetTilePropertySet(unsigned gid) const;
 
+    /// Return tile frame set by gid, if not exist return 0.
+    FrameSet2D* GetTileFrameSet(unsigned gid) const;
+
+    /// Updates FrameSet's timers, in all tile sets.
+    void UpdateAnimationTimers(float timeStep);
+
     /// Return number of layers.
     unsigned GetNumLayers() const { return layers_.Size(); }
 
@@ -223,6 +229,8 @@ private:
     HashMap<unsigned, SharedPtr<Sprite2D> > gidToSpriteMapping_;
     /// Gid to tile property set mapping.
     HashMap<unsigned, SharedPtr<PropertySet2D> > gidToPropertySetMapping_;
+    /// Gid to tile frame set mapping.
+    HashMap<unsigned, SharedPtr<FrameSet2D> > gidToFrameSetMapping_;
     /// Gid to tile collision shape mapping.
     HashMap<unsigned, Vector<SharedPtr<TileMapObject2D> > > gidToCollisionShapeMapping_;
     /// Layers.


### PR DESCRIPTION
These changes play animated tiles in tmx tilemaps.
I had opened a pull request in Urho3D before, but at the time a lot of the LUA and Angel script bindings were missing.
I finally made the transition to U3D and since the bindings are now done, I'm opening a new PR.