### PR TITLE
Fix Issues Building For Web on Windows

### DIFF
--- a/Source/Tools/CMakeLists.txt
+++ b/Source/Tools/CMakeLists.txt
@@ -48,27 +48,33 @@ if (CMAKE_CROSSCOMPILING)
     else ()
         set (ALTERNATE_COMMAND CMAKE_COMMAND ${CMAKE_COMMAND} -E env CC=${SAVED_CC} CXX=${SAVED_CXX} CI=$ENV{CI} ${CMAKE_COMMAND})
     endif ()
+    # When building for Web on Windows, add ".exe" extension to the file names of PackageTool and BindingGenerator executables to prevent failure of not finding these files during installation.
+    if (WEB AND CMAKE_HOST_WIN32)
+        set (FILE_EXTENSION ".exe")
+    else ()
+        set (FILE_EXTENSION "")
+    endif ()
     if (URHO3D_PACKAGING)
         ExternalProject_Add (PackageTool
             SOURCE_DIR ${CMAKE_SOURCE_DIR}/Source/Tools/PackageTool
             CMAKE_ARGS -D URHO3D_DEPLOYMENT_TARGET=generic -D DEST_RUNTIME_DIR=${CMAKE_BINARY_DIR}/bin/tool -D BAKED_CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR} -D BAKED_CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR} -D CMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
             ${ALTERNATE_COMMAND})
-        add_make_clean_files (${CMAKE_BINARY_DIR}/bin/tool/PackageTool)
+        add_make_clean_files (${CMAKE_BINARY_DIR}/bin/tool/PackageTool${FILE_EXTENSION})
         if (CMAKE_HOST_WIN32 AND NOT HAS_MKLINK)
             add_dependencies (PackageTool Urho3D)   # Ensure Urho3D headers are fresh when building PackageTool externally on Windows host system without MKLINK
         endif ()
-        install (PROGRAMS ${CMAKE_BINARY_DIR}/bin/tool/PackageTool DESTINATION ${DEST_RUNTIME_DIR}/tool)
+        install (PROGRAMS ${CMAKE_BINARY_DIR}/bin/tool/PackageTool${FILE_EXTENSION} DESTINATION ${DEST_RUNTIME_DIR}/tool)
     endif ()
     if (URHO3D_GENERATEBINDINGS)
         ExternalProject_Add (BindingGenerator
             SOURCE_DIR ${CMAKE_SOURCE_DIR}/Source/Tools/BindingGenerator
             CMAKE_ARGS -D URHO3D_DEPLOYMENT_TARGET=generic -D DEST_RUNTIME_DIR=${CMAKE_BINARY_DIR}/bin/tool -D BAKED_CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR} -D BAKED_CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR} -D CMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
             ${ALTERNATE_COMMAND})
-        add_make_clean_files (${CMAKE_BINARY_DIR}/bin/tool/BindingGenerator)
+        add_make_clean_files (${CMAKE_BINARY_DIR}/bin/tool/BindingGenerator${FILE_EXTENSION})
         if (CMAKE_HOST_WIN32 AND NOT HAS_MKLINK)
             add_dependencies (BindingGenerator Urho3D)
         endif ()
-        install (PROGRAMS ${CMAKE_BINARY_DIR}/bin/tool/BindingGenerator DESTINATION ${DEST_RUNTIME_DIR}/tool)
+        install (PROGRAMS ${CMAKE_BINARY_DIR}/bin/tool/BindingGenerator${FILE_EXTENSION} DESTINATION ${DEST_RUNTIME_DIR}/tool)
     endif ()
 endif ()
 

--- a/script/cmake_generic.bat
+++ b/script/cmake_generic.bat
@@ -45,6 +45,8 @@ set "OPTS="
 set "BUILD_OPTS="
 set "arch="
 :loop
+:: Cache the first argument so substring operation can be performed on it
+set "ARG1=%~1"
 if not "%~1" == "" (
     if "%~1" == "-D" (
         if "%~2" == "MINGW" if "%~3" == "1" set "OPTS=-G "MinGW Makefiles""
@@ -54,6 +56,11 @@ if not "%~1" == "" (
         shift
         shift
         shift
+    ) else if "%ARG1:~0,2%" == "-D" (
+        :: Handle case where there is no space after "-D" in the options
+        set "BUILD_OPTS=%BUILD_OPTS% %~1=%~2"
+        shift
+        shift
     )
     if "%~1" == "-VS" (
         set "OPTS=-G "Visual Studio %~2" %arch% %TOOLSET%"
@@ -61,7 +68,12 @@ if not "%~1" == "" (
         shift
     )
     if "%~1" == "-G" (
-        set "OPTS=%OPTS% -G %~2"
+        :: Add quote to MinGW Makefiles flag since Emscripten's emcmake emits them without quotes and this breaks cmake
+        if "%~2" == "MinGW Makefiles" (
+            set "OPTS=%OPTS% -G "%~2""
+        ) else (
+            set "OPTS=%OPTS% -G %~2"
+        )
         shift
         shift
     )


### PR DESCRIPTION
Two issues are currently encountered when building Urho3D for Web on Windows. 

1. While setting up a build by directly or indirectly calling [script\cmake_generic.bat](https://github.com/u3d-community/U3D/blob/master/script/cmake_generic.bat), an infinite loop will occur when the `-D` options is not followed by a space, see #59. Example `script\cmake_vs2022.bat build -DURHO3D_SAMPLES=1`. This can easily be avoided by adding the needed space after `-D`. However when used with Emscripten's `emcmake` to setup for Web, the infinite loop will be encountered once more because `emcmake` emits the `CMAKE_TOOLCHAIN_FILE` and `CMAKE_CROSSCOMPILING_EMULATOR` build options with no space after `-D`. 

	
	Additionally, `emcmake` emits the MinGW makefiles generator flag without quotes around `MinGW Makefiles` and this breaks CMake.
	
	
2. In [Source\Tools\CMakeLists.txt](https://github.com/u3d-community/U3D/blob/master/Source/Tools/CMakeLists.txt), the CMake command to install `PackageTool` and `BindingGenerator` under the `CMAKE_CROSSCOMPILING` option specifies these files without an extension. When building for Web on Windows, the builds are successful but installation fails with error `file INSTALL cannot find <path/to/file>` because the file being looked for has no extension while the actual file that was built has `.exe` extension.



This PR fixes the above mentioned issues and was tested on a Windows 11 machine using Emscripten version `3.1.59` ( the latest version at the time of this post)

