### PR TITLE
Fix incorrectly read 'wrapmode' in Animatable

### DIFF
--- a/Source/Urho3D/Scene/Animatable.cpp
+++ b/Source/Urho3D/Scene/Animatable.cpp
@@ -100,7 +100,7 @@ bool Animatable::LoadXML(const XMLElement& source)
         if (!attributeAnimation->LoadXML(elem))
             return false;
 
-        String wrapModeString = source.GetAttribute("wrapmode");
+        String wrapModeString = elem.GetAttribute("wrapmode");
         WrapMode wrapMode = WM_LOOP;
         for (int i = 0; i <= WM_CLAMP; ++i)
         {


### PR DESCRIPTION
'wrapmode' attribute was incorrectly read from XMLElement instead of the attributeanimation, always defaulting it to WM_LOOP