### PR TITLE
Fix linux build issues for Wayland and X11(NOSHARED) : link dependencies from sdl.

### DIFF
--- a/Source/ThirdParty/SDL/cmake/sdlchecks.cmake
+++ b/Source/ThirdParty/SDL/cmake/sdlchecks.cmake
@@ -665,9 +665,12 @@ macro(CheckWayland)
           set(SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR "\"${WAYLAND_CURSOR_LIB_SONAME}\"")
           set(SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON "\"${XKBCOMMON_LIB_SONAME}\"")
           set(HAVE_WAYLAND_SHARED TRUE)
+          # workaround, add wayland-client for the moment
+          list (APPEND EXTRA_LIBS wayland-client)
         endif()
       else()
-        list (APPEND EXTRA_LIBS wayland-client)
+        # add all wayland dependencies
+        list (APPEND EXTRA_LIBS xkbcommon wayland-client wayland-egl wayland-cursor)
       endif()
 
       set(SDL_VIDEO_DRIVER_WAYLAND 1)

--- a/cmake/Modules/UrhoCommon.cmake
+++ b/cmake/Modules/UrhoCommon.cmake
@@ -894,7 +894,10 @@ macro (define_dependency_libs TARGET)
             list (APPEND LIBS dl log android)
         else ()
             # Linux
-            if (NOT WEB)
+            if (${TARGET} MATCHES SDL)
+                # set external libraries dependencies for SDL and add them later to URHO3D
+                set (URHO3D_LIBRARIES ${EXTRA_LIBS} PARENT_SCOPE)
+            elseif (NOT WEB)                
                 list (APPEND LIBS dl m rt)
             endif ()
             if (RPI)


### PR DESCRIPTION
solve undefined reference to « wl_proxy_get_version » in libUrho3D.a(SDL_waylandvideo.c.o)
Get extra libs (ex: X11, Xcursor ... or wayland-client) needed by sdl and link with urho3d lib.