### PR TITLE
Add events for AttributeAnimation

### DIFF
--- a/Source/Urho3D/Scene/Animatable.h
+++ b/Source/Urho3D/Scene/Animatable.h
@@ -146,9 +146,9 @@ protected:
     /// Return attribute animation info.
     AttributeAnimationInfo* GetAttributeAnimationInfo(const String& name) const;
     /// Handle attribute animation added.
-    void HandleAttributeAnimationAdded(StringHash eventType, VariantMap& eventData);
+    void HandleObjectAttributeAnimationAdded(StringHash eventType, VariantMap& eventData);
     /// Handle attribute animation removed.
-    void HandleAttributeAnimationRemoved(StringHash eventType, VariantMap& eventData);
+    void HandleObjectAttributeAnimationRemoved(StringHash eventType, VariantMap& eventData);
 
     /// Animation enabled.
     bool animationEnabled_;

--- a/Source/Urho3D/Scene/ObjectAnimation.cpp
+++ b/Source/Urho3D/Scene/ObjectAnimation.cpp
@@ -298,20 +298,20 @@ ValueAnimationInfo* ObjectAnimation::GetAttributeAnimationInfo(const String& nam
 
 void ObjectAnimation::SendAttributeAnimationAddedEvent(const String& name)
 {
-    using namespace AttributeAnimationAdded;
+    using namespace ObjectAttributeAnimationAdded;
     VariantMap& eventData = GetEventDataMap();
     eventData[P_OBJECTANIMATION] = this;
     eventData[P_ATTRIBUTEANIMATIONNAME] = name;
-    SendEvent(E_ATTRIBUTEANIMATIONADDED, eventData);
+    SendEvent(E_OBJECTATTRIBUTEANIMATIONADDED, eventData);
 }
 
 void ObjectAnimation::SendAttributeAnimationRemovedEvent(const String& name)
 {
-    using namespace AttributeAnimationRemoved;
+    using namespace ObjectAttributeAnimationRemoved;
     VariantMap& eventData = GetEventDataMap();
     eventData[P_OBJECTANIMATION] = this;
     eventData[P_ATTRIBUTEANIMATIONNAME] = name;
-    SendEvent(E_ATTRIBUTEANIMATIONREMOVED, eventData);
+    SendEvent(E_OBJECTATTRIBUTEANIMATIONREMOVED, eventData);
 }
 
 }

--- a/Source/Urho3D/Scene/SceneEvents.h
+++ b/Source/Urho3D/Scene/SceneEvents.h
@@ -72,15 +72,27 @@ URHO3D_EVENT(E_ATTRIBUTEANIMATIONUPDATE, AttributeAnimationUpdate)
     URHO3D_PARAM(P_TIMESTEP, TimeStep);            // float
 }
 
-/// Attribute animation added to object animation.
+/// Attribute animation added directly to animatable.
 URHO3D_EVENT(E_ATTRIBUTEANIMATIONADDED, AttributeAnimationAdded)
+{
+    URHO3D_PARAM(P_ATTRIBUTEANIMATIONNAME, AttributeAnimationName); // String
+}
+
+/// Attribute animation that was added directly to animatable was removed.
+URHO3D_EVENT(E_ATTRIBUTEANIMATIONREMOVED, AttributeAnimationRemoved)
+{
+    URHO3D_PARAM(P_ATTRIBUTEANIMATIONNAME, AttributeAnimationName); // String
+}
+
+/// Attribute animation added to object animation.
+URHO3D_EVENT(E_OBJECTATTRIBUTEANIMATIONADDED, ObjectAttributeAnimationAdded)
 {
     URHO3D_PARAM(P_OBJECTANIMATION, ObjectAnimation);               // Object animation pointer
     URHO3D_PARAM(P_ATTRIBUTEANIMATIONNAME, AttributeAnimationName); // String
 }
 
 /// Attribute animation removed from object animation.
-URHO3D_EVENT(E_ATTRIBUTEANIMATIONREMOVED, AttributeAnimationRemoved)
+URHO3D_EVENT(E_OBJECTATTRIBUTEANIMATIONREMOVED, ObjectAttributeAnimationRemoved)
 {
     URHO3D_PARAM(P_OBJECTANIMATION, ObjectAnimation);               // Object animation pointer
     URHO3D_PARAM(P_ATTRIBUTEANIMATIONNAME, AttributeAnimationName); // String


### PR DESCRIPTION
Adds added/removed events to attribute animations. Not related to ObjectAnimation!

This could be a bit destructive, since it renames the existing E_ATTRIBUTEANIMATIONADDED event to E_OBJECTATTRIBUTEANIMATIONADDED, and uses the E_ATTRIBUTEANIMATIONADDED name to refer to non-ObjectAnimation attribute animations.

So:
Object attribute animation added = E_OBJECTATTRIBUTEANIMATIONADDED (was E_ATTRIBUTEANIMATIONADDED)
Non-object attribute animation added = E_ATTRIBUTEANIMATIONADDED (event for this didn't exist before)