### PR TITLE
Androidfixes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,7 +24,7 @@ jobs:
       DBE_TAG: master
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - name: Free up space
         run: |
@@ -35,7 +35,7 @@ jobs:
         id: source_checksum
         run: rake source_checksum
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             build/cache/.ccache
@@ -71,7 +71,7 @@ jobs:
           rm -rf build/cache/.m2
           find build/cache/.gradle -newer build/cache/.gradle/mark -type d |xargs rm -rf
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-${{ matrix.lib-type }}-all-both
           path: |
@@ -88,8 +88,6 @@ jobs:
           PUBLISHER_NAME: ${{ secrets.PUBLISHER_NAME }}
           PUBLISHER_EMAIL: ${{ secrets.PUBLISHER_EMAIL }}
           PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
         run: script/dockerized.sh ${PLATFORM/-*} rake publish
         if: |
           github.event_name == 'push' &&

--- a/android/launcher-app/build.gradle.kts
+++ b/android/launcher-app/build.gradle.kts
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2008-2022 the Urho3D project.
+// Copyright (c) 2022-2024 the U3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +23,9 @@
 
 plugins {
     id("com.android.application")
-    kotlin("android")
-    kotlin("android.extensions")
+    id("org.jetbrains.kotlin.android")
 }
-
+    
 val kotlinVersion: String by ext
 val ndkSideBySideVersion: String by ext
 val cmakeVersion: String by ext
@@ -34,56 +34,60 @@ val buildStagingDir: String by ext
 android {
     ndkVersion = ndkSideBySideVersion
     compileSdkVersion(30)
-    defaultConfig {
-        minSdkVersion(18)
-        targetSdkVersion(30)
-        applicationId = "io.urho3d.launcher"
-        versionCode = 1
-        versionName = project.version.toString()
-        testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
-        externalNativeBuild {
-            cmake {
-                arguments.apply {
-                    System.getenv("ANDROID_CCACHE")?.let { add("-D ANDROID_CCACHE=$it") }
-                    add("-D BUILD_STAGING_DIR=${findProject(":android:urho3d-lib")!!.projectDir}/$buildStagingDir")
-                    add("-D URHO3D_PLAYER=1")
-                    // Skip building samples for 'STATIC' lib type to reduce the spacetime requirement
-                    add("-D URHO3D_SAMPLES=${if (System.getenv("URHO3D_LIB_TYPE") == "SHARED") "1" else "0"}")
-                    // Pass along matching env-vars as CMake build options
-                    addAll(project.file("../../script/.build-options")
-                        .readLines()
-                        .filterNot { listOf("URHO3D_PLAYER", "URHO3D_SAMPLES").contains(it) }
-                        .mapNotNull { variable -> System.getenv(variable)?.let { "-D $variable=$it" } }
+
+    // android : the launcher-app has always an shared build
+    if (LibType() == "shared")
+    {
+        defaultConfig {
+            minSdkVersion(19)
+            targetSdkVersion(30)
+            applicationId = "io.urho3d.launcher"
+            versionCode = 1
+            versionName = project.version.toString()
+            testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
+            externalNativeBuild {
+                cmake {
+                    arguments.apply {
+                        System.getenv("ANDROID_CCACHE")?.let { add("-D ANDROID_CCACHE=$it") }
+                        add("-D BUILD_STAGING_DIR=${findProject(":android:urho3d-lib")!!.projectDir}/$buildStagingDir/shared")
+                        add("-D URHO3D_PLAYER=1")
+                        add("-D URHO3D_SAMPLES=1")
+                        // Pass along matching env-vars as CMake build options
+                        addAll(project.file("../../script/.build-options")
+                            .readLines()
+                            .filterNot { listOf("URHO3D_PLAYER", "URHO3D_SAMPLES").contains(it) }
+                            .mapNotNull { variable -> System.getenv(variable)?.let { "-D $variable=$it" } }
+                        )
+                    }
+                }
+            }
+            splits {
+                abi {
+                    isEnable = project.hasProperty("ANDROID_ABI")
+                    reset()
+                    include(
+                        *(project.findProperty("ANDROID_ABI") as String? ?: "")
+                            .split(',')
+                            .toTypedArray()
                     )
                 }
             }
         }
-        splits {
-            abi {
-                isEnable = project.hasProperty("ANDROID_ABI")
-                reset()
-                include(
-                    *(project.findProperty("ANDROID_ABI") as String? ?: "")
-                        .split(',')
-                        .toTypedArray()
-                )
+        buildTypes {
+            named("release") {
+                isMinifyEnabled = false
+                proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            }
+        }        
+        externalNativeBuild {
+            cmake {
+                version = cmakeVersion
+                path = project.file("CMakeLists.txt")
+                buildStagingDirectory(buildStagingDir)
             }
         }
-    }
-    buildTypes {
-        named("release") {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-        }
-    }
-    lintOptions {
-        isAbortOnError = false
-    }
-    externalNativeBuild {
-        cmake {
-            version = cmakeVersion
-            path = project.file("CMakeLists.txt")
-            setBuildStagingDirectory(buildStagingDir)
+        lintOptions {
+            isAbortOnError = false
         }
     }
 }
@@ -100,20 +104,35 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
 }
 
-afterEvaluate {
-    android.buildTypes.forEach {
-        val config = it.name.capitalize()
-        tasks {
-            "externalNativeBuild$config" {
-                mustRunAfter(":android:urho3d-lib:externalNativeBuild$config")
+if (LibType() == "shared")
+{
+    afterEvaluate {
+        android.buildTypes.forEach {
+            val config = it.name.capitalize()
+            tasks {
+                "externalNativeBuild$config" {
+                    mustRunAfter(":android:urho3d-lib:externalNativeBuild$config")
+                }
             }
         }
     }
+    tasks {
+        register<Delete>("cleanAll") {
+            dependsOn("clean")
+            delete = setOf(android.externalNativeBuild.cmake.buildStagingDirectory)
+        }
+    }
+}
+else {
+    afterEvaluate {
+        tasks.configureEach {
+            enabled = false
+        }
+        println("the launcher-app build cannot be done with 'static' library type.")
+        println("To build it, type in a terminal : URHO3D_LIB_TYPE=SHARED ./gradlew build")
+    }
 }
 
-tasks {
-    register<Delete>("cleanAll") {
-        dependsOn("clean")
-        delete = setOf(android.externalNativeBuild.cmake.buildStagingDirectory)
-    }
+fun LibType(): String {
+    return System.getenv("URHO3D_LIB_TYPE")?.toLowerCase() ?: "static"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2008-2022 the Urho3D project.
+// Copyright (c) 2022-2024 the U3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,39 +25,44 @@ import org.gradle.internal.io.NullOutputStream
 import java.io.ByteArrayOutputStream
 
 buildscript {
+    extra["agpVersion"] = "4.2.0"
     extra["kotlinVersion"] = "1.4.10"
+    val agpVersion: String by extra
     val kotlinVersion: String by extra
+    
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
+    
     dependencies {
-        classpath("com.android.tools.build:gradle:4.0.2")
+        classpath("com.android.tools.build:gradle:$agpVersion")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
 
-plugins {
-    id("com.jfrog.bintray") version "1.8.5" apply false
-}
-
+val agpVersion: String by ext
 val kotlinVersion: String by ext
 
 allprojects {
-    group = "io.urho3d"
+    group = "io.u3d"
     version = determineVersion()
     description = """
         Urho3D is a free lightweight, cross-platform 2D and 3D game engine implemented in C++ and
         released under the MIT license. Greatly inspired by OGRE and Horde3D.
     """.trimIndent().replace('\n', ' ')
+
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        mavenLocal()
     }
+    
     buildscript {
         ext {
-            set("kotlinVersion", kotlinVersion)
-            set("ndkSideBySideVersion", "21.3.6528147")
+            set("agpVersion", "$agpVersion")
+            set("kotlinVersion", "$kotlinVersion")
+            set("ndkSideBySideVersion", "21.4.7075529")
             set("cmakeVersion", "3.17.3+")
             set("buildStagingDir", ".cxx")
         }

--- a/cmake/Modules/FindUrho3D.cmake
+++ b/cmake/Modules/FindUrho3D.cmake
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2008-2022 the Urho3D project.
+# Copyright (c) 2022-2024 the U3D project.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -147,7 +148,11 @@ else ()
         list (APPEND CMAKE_PREFIX_PATH ${URHO3D_HOME})
         set (SEARCH_OPT NO_CMAKE_FIND_ROOT_PATH)
     endif ()
-    find_path (URHO3D_BASE_INCLUDE_DIR Urho3D.h PATH_SUFFIXES ${PATH_SUFFIX} ${SEARCH_OPT} DOC "Urho3D include directory")
+    if (ANDROID AND URHO3D_HOME)
+        set (URHO3D_BASE_INCLUDE_DIR ${URHO3D_HOME}/include/Urho3D)
+    else ()
+        find_path (URHO3D_BASE_INCLUDE_DIR Urho3D.h PATH_SUFFIXES ${PATH_SUFFIX} ${SEARCH_OPT} DOC "Urho3D include directory")
+    endif ()
     if (URHO3D_BASE_INCLUDE_DIR)
         get_filename_component (URHO3D_INCLUDE_DIRS ${URHO3D_BASE_INCLUDE_DIR} PATH)
         if (NOT URHO3D_HOME)

--- a/cmake/Modules/UrhoCommon.cmake
+++ b/cmake/Modules/UrhoCommon.cmake
@@ -508,6 +508,9 @@ if (WIN32 AND NOT CMAKE_PROJECT_NAME MATCHES ^Urho3D-ExternalProject-)
     endif ()
 endif ()
 
+# SDL_LIBS : allow to link against Urho3D th external LIBS from SDL
+set (SDL_LIBS)
+
 # Platform and compiler specific options
 set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -894,16 +897,20 @@ macro (define_dependency_libs TARGET)
             list (APPEND LIBS dl log android)
         else ()
             # Linux
-            if (${TARGET} MATCHES SDL)
-                # set external libraries dependencies for SDL and add them later to URHO3D
-                set (URHO3D_LIBRARIES ${EXTRA_LIBS} PARENT_SCOPE)
-            elseif (NOT WEB)                
+            if (NOT WEB)
                 list (APPEND LIBS dl m rt)
             endif ()
             if (RPI)
                 list (APPEND ABSOLUTE_PATH_LIBS ${VIDEOCORE_LIBRARIES})
             endif ()
         endif ()
+    endif ()
+
+    # Set extra dependencies from SDL and add them later to URHO3D
+    # Android : need OpenSLES
+    # Linux   : may need Wayland and X11 (only for X11-static)
+    if (${TARGET} MATCHES SDL)
+       set (SDL_LIBS ${EXTRA_LIBS} PARENT_SCOPE)
     endif ()
 
     # ThirdParty/Civetweb external dependency
@@ -1779,7 +1786,9 @@ macro (_setup_target)
     include_directories (${INCLUDE_DIRS})
     # Link libraries
     define_dependency_libs (${TARGET_NAME})
-    target_link_libraries (${TARGET_NAME} ${ABSOLUTE_PATH_LIBS} ${LIBS})
+    # Needed external libraries for the current target (SDL_LIBS added)
+    target_link_libraries (${TARGET_NAME} ${ABSOLUTE_PATH_LIBS} ${SDL_LIBS} ${LIBS})
+    set (SDL_LIBS)
     # Enable PCH if requested
     if (${TARGET_NAME}_HEADER_PATHNAME)
         enable_pch (${${TARGET_NAME}_HEADER_PATHNAME})

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,17 @@
+
+## Build Docker Images
+
+This folder contains Dockerfiles for building Docker images to use locally or with GitHub workflows.
+
+Once you have built the Docker images on your system, you can simply run `./script/dockerized.sh`, and it will use these local images.
+
+Currently, the following Dockerfiles are available:
+
+### Android Build:
+
+    To build the Docker image, you will need 6 GB of free space and Docker installed.
+    Then, open a terminal in the `u3d-android` subfolder and run:
+    ```bash
+    docker build -t u3d-android .
+    ```
+    (You’ll need to prefix this command with sudo if your Docker user permissions are not configured.)

--- a/docker/u3d-android/Dockerfile
+++ b/docker/u3d-android/Dockerfile
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2018-2022 Yao Wei Tjong. All rights reserved.
+# Copyright (c) 2022-2024 the U3D project.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+FROM ubuntu:22.04
+
+# 'base'
+
+ARG cmake_url=https://cmake.org/files/v3.22/cmake-3.22.6-linux-x86_64.tar.gz
+ARG lang=en_US.UTF-8
+
+ENV USE_CCACHE=1 \
+    CCACHE_SLOPPINESS=pch_defines,time_macros \
+    CCACHE_COMPRESS=1 \
+    HOST_UID=1000 \
+    HOST_GID=1000 \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt upgrade -y && \
+    apt install -y --no-install-recommends \
+    build-essential ccache git g++-multilib ninja-build doxygen graphviz \
+    locales curl openssh-client rake rsync sudo tzdata vim wget unzip && \
+    wget -qO- ${cmake_url} | tar --strip-components=1 -xzC /usr/local && \
+    locale-gen ${lang} && update-locale LANG=${lang}
+
+# 'android'
+
+ARG tool_url=https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip
+ARG tool_version=30.0.2
+ARG ndk_version=21.4.7075529
+ARG platform=30
+
+ENV PLATFORM=android \
+    ANDROID_HOME=/android-sdk \
+    ANDROID_CCACHE=/usr/bin/ccache
+
+RUN apt install -y --no-install-recommends openjdk-11-jdk-headless && \
+    mkdir -p ${ANDROID_HOME}/cmdline-tools && cd ${ANDROID_HOME}/cmdline-tools && \
+    wget -qO- ${tool_url} -O cmdline-tools.zip && \
+    unzip cmdline-tools.zip && rm cmdline-tools.zip && \
+    mv cmdline-tools latest && cd latest/bin && \
+    yes | ./sdkmanager --install "build-tools;${tool_version}" "ndk;${ndk_version}" "platforms;android-${platform}" && \
+    yes | ./sdkmanager --uninstall "emulator" && \
+    yes | ./sdkmanager --licenses
+
+RUN apt clean
+
+VOLUME /home/U3D
+
+COPY sysroot/ /
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/usr/bin/rake"]

--- a/docker/u3d-android/sysroot/entrypoint.sh
+++ b/docker/u3d-android/sysroot/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2022 Yao Wei Tjong. All rights reserved.
+# Copyright (c) 2022-2024 the U3D project.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# Check if the host project root is correctly mounted before proceeding further
+if [[ ! $PROJECT_DIR || -z $(ls -1 $PROJECT_DIR 2>/dev/null) ]]; then
+    echo -e "Error: PROJECT_DIR env-var must be set to project root directory from host.
+       See 'script/dockerized.sh' in the Urho3D project as use case sample."
+    exit 1
+fi
+
+# Enable history-search in bash completion
+sed -i '/^#.*history-search/s/^# //' /etc/inputrc
+
+# Delay updating the symlinks to runtime after all compiler toolchains have been installed
+/usr/sbin/update-ccache-symlinks
+
+# Ensure ccache is being found first
+PATH=/usr/lib/ccache:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH
+
+# Use the built-in locale from the docker image
+set -a && . /etc/default/locale && set +a
+
+if [[ "$container" == "podman" ]]; then
+    # Change home dir for this session
+    HOME=/home/U3D
+    # Set Gradle user home to a dir mounted from pod's volume so Gradle caches are persisted
+    export GRADLE_USER_HOME=~/.gradle
+    # Set Maven local repository to a mounted dir for similar reason as above
+    mkdir -p /root/.m2
+    echo '<settings><localRepository>/home/U3D/.m2/repository</localRepository></settings>' >/root/.m2/settings.xml
+    
+    echo "EXECUTE podman project:$PROJECT_DIR $@"
+    # Execute the command chain (relative to project root) as is since we run Podman in rootless mode
+    cd $PROJECT_DIR && exec "$@"
+else
+    # Delay group and user creation to runtime to match the host GID and host UID
+    groupadd -g $HOST_GID U3D && useradd -u $HOST_UID -g $HOST_GID -s /bin/bash U3D
+
+    # Allow 'U3D' user to write into mounted docker volumes
+    chmod o+w /home/U3D
+
+    # With great power comes great responsibility
+    echo "U3D ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/super_u3d
+
+    echo "EXECUTE project:$PROJECT_DIR $@"
+    # Execute the command chain (relative to project root) as urho3d
+    cd $PROJECT_DIR && runuser -u U3D -- "$@"
+fi
+
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/rakefile
+++ b/rakefile
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2008-2022 the Urho3D project.
+# Copyright (c) 2022-2024 the U3D project.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -138,7 +139,7 @@ end
 desc 'Publish build artifact'
 task :publish => [:init] do
   if ENV['PLATFORM'] == 'android'
-    Rake::Task[:gradle].invoke("publish #{/refs\/tags\// =~ ENV['GITHUB_REF'] ? 'bintrayUpload' : ''}")
+    Rake::Task[:gradle].invoke('publish')
     next
   end
   Rake::Task[$publish_task.to_sym].invoke if $publish_task
@@ -557,7 +558,7 @@ android {
         cmake {
             version = cmakeVersion
             path = project.file("../CMakeLists.txt")
-            setBuildStagingDirectory(buildStagingDir)
+            buildStagingDirectory(buildStagingDir)
         }
     }
     sourceSets {
@@ -574,8 +575,8 @@ val urhoDebugImpl by configurations.creating { isCanBeResolved = true }
 configurations.debugImplementation.get().extendsFrom(urhoDebugImpl)
 
 dependencies {
-    urhoReleaseImpl("io.urho3d:urho3d-lib-#{type}:#{aar_version}")
-    urhoDebugImpl("io.urho3d:urho3d-lib-#{type}-debug:#{aar_version}")
+    urhoReleaseImpl("io.u3d:urho3d-lib-#{type}:#{aar_version}")
+    urhoDebugImpl("io.u3d:urho3d-lib-#{type}-debug:#{aar_version}")
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar", "*.aar"))))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     implementation("androidx.core:core-ktx:#{first_match(/"androidx.core:core-ktx:(.+)"/, template)}")
@@ -617,14 +618,16 @@ def root_build_gradle_kts(_)
   template = File.readlines('build.gradle.kts')
   <<-EOF
 buildscript {
+    extra["agpVersion"] = "#{first_match(/extra\["agpVersion"\] = "(.+)"/, template)}"
     extra["kotlinVersion"] = "#{first_match(/extra\["kotlinVersion"\] = "(.+)"/, template)}"
+    val agpVersion: String by extra
     val kotlinVersion: String by extra
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:#{first_match(/"com.android.tools.build:gradle:(.+)"/, template)}")
+        classpath("com.android.tools.build:gradle:$agpVersion")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
@@ -634,7 +637,7 @@ val kotlinVersion: String by ext
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         // Remove below two repos if you are only using released AAR from JCenter
         mavenLocal()
         if (System.getenv("GITHUB_ACTOR") != null && System.getenv("GITHUB_TOKEN") != null) {

--- a/script/dockerized.sh
+++ b/script/dockerized.sh
@@ -66,7 +66,11 @@ platform=$1; shift
 # temporary workaround for testing
 if [[ "$platform" == "android" ]]; then
     fishbone="U3D"
-    dbe_image="okkoman/u3d-android:latest"
+    if [[ $GITHUB_ACTIONS ]]; then
+        dbe_image="okkoman/u3d-android:latest"
+    else
+        dbe_image="u3d-android"
+    fi    
 else
     fishbone="urho3d"
     if [[ "$DBE_NAMING_SCHEME" == "tag" ]]; then

--- a/script/dockerized.sh
+++ b/script/dockerized.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright (c) 2008-2022 the Urho3D project.
+# Copyright (c) 2022-2024 the U3D project.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -62,10 +63,17 @@ fi
 
 platform=$1; shift
 
-if [[ "$DBE_NAMING_SCHEME" == "tag" ]]; then
-  dbe_image=$DBE_NAME:$DBE_TAG-$platform
+# temporary workaround for testing
+if [[ "$platform" == "android" ]]; then
+    fishbone="U3D"
+    dbe_image="okkoman/u3d-android:latest"
 else
-  dbe_image=$DBE_NAME-$platform:$DBE_TAG
+    fishbone="urho3d"
+    if [[ "$DBE_NAMING_SCHEME" == "tag" ]]; then
+      dbe_image=$DBE_NAME:$DBE_TAG-$platform
+    else
+      dbe_image=$DBE_NAME-$platform:$DBE_TAG
+    fi
 fi
 
 if [[ $DBE_REFRESH == 1 ]]; then
@@ -73,9 +81,9 @@ if [[ $DBE_REFRESH == 1 ]]; then
 fi
 if [[ $GITHUB_ACTIONS ]]; then
   mkdir -p $GITHUB_WORKSPACE/build/cache
-  mount_home_dir="--mount type=bind,source=$GITHUB_WORKSPACE/build/cache,target=/home/urho3d$mount_option"
+  mount_home_dir="--mount type=bind,source=$GITHUB_WORKSPACE/build/cache,target=/home/$fishbone$mount_option"
 else
-  mount_home_dir="--mount type=volume,source=$(id -u).urho3d_home_dir,target=/home/urho3d$mount_option"
+  mount_home_dir="--mount type=volume,source=$(id -u).urho3d_home_dir,target=/home/$fishbone$mount_option"
   interactive=-i
 fi
 if [[ $use_podman ]] || ( [[ $(d version -f '{{.Client.Version}}') =~ ^([0-9]+)\.0*([0-9]+)\. ]] && (( BASH_REMATCH[1] * 100 + BASH_REMATCH[2] >= 1809 )) ); then

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2008-2022 the Urho3D project.
+// Copyright (c) 2022-2024 the U3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,4 +21,7 @@
 // THE SOFTWARE.
 //
 
-include(":android:urho3d-lib", ":android:launcher-app")
+rootProject.name = "U3D"
+
+include(":android:urho3d-lib")
+include(":android:launcher-app")


### PR DESCRIPTION
These commits fix the android build :

-> add Library dependencies from SDL to urho build

-> update to gradle 6.7.1, android gradle plugin (AGP) 4.2.0

-> add a new temporary docker image okkoma/u3d-android with the required android build tool 30.0.2 :
we'll have to change this docker to u3d/ud3-android in the next step. Look at the docker file in ./docker/u3d-android, to see the content of the new docker image (it's a patch of the previous script by Wei Tjong). We could also add to it some other android platforms like android-21. 

-> fix the build.gradle.kts for local use :
--> we can now build static and shared in the same build tree.
--> always remove urho launcher-app and samples in static build.

-> remove bintray (it's dead since 2021).

-> update android workflow : to cache v4

