### PR TITLE
Fix win-gcc (issue #34)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,15 +6,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  windows:
-    name: 🏁
+  windows-vs:
+    name: win-vs 🏁
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - win-vs
-          - win-gcc
+
         lib-type:
           - static
           - shared
@@ -23,10 +21,67 @@ jobs:
           - OpenGL
     env:
       HOST: ${{ github.job }}
-      PLATFORM: ${{ matrix.platform }}
+      PLATFORM: win-vs
       LIB_TYPE: ${{ matrix.lib-type }}
       GRAPHICS_API: ${{ matrix.graphics-api }}
       URHO3D_DOCS: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Set cache TTL
+        run: |
+          echo ("CACHE_MONTH=" + $(date '+%b %Y')) >> $env:GITHUB_ENV
+      - name: CMake
+        run: rake cmake
+      - name: Build
+        run: rake build
+      - name: Test
+        run: rake test
+        if: matrix.graphics-api != 'OpenGL'
+      - name: Install
+        run: rake install
+      - name: Scaffolding - new
+        run: rake new
+      - name: Scaffolding - build
+        run: |
+          cd ~/projects/UrhoApp
+          rake
+      - name: Scaffolding - test
+        run: |
+          cd ~/projects/UrhoApp
+          rake test
+        if: matrix.graphics-api != 'OpenGL'
+      - name: Scaffolding - cleanup
+        run: rm -r -fo ~/.urho3d, ~/Projects
+      - name: Package
+        run: rake package
+        if: github.event_name == 'push'
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: win-vs-${{ matrix.lib-type }}-64-${{ matrix.graphics-api }}-rel
+          path: build/ci/*.zip
+        if: github.event_name == 'push'
+  windows-gcc:
+    name: win-gcc 🏁
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lib-type:
+          - static
+          - shared
+        graphics-api:
+          - DX11
+          - OpenGL
+    env:
+      HOST: ${{ github.job }}
+      PLATFORM: win-gcc
+      LIB_TYPE: ${{ matrix.lib-type }}
+      GRAPHICS_API: ${{ matrix.graphics-api }}
+      URHO3D_DOCS: 0
+      MINGW_SYSROOT: 'C:/ProgramData/chocolatey/lib/mingw'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,15 +91,14 @@ jobs:
           echo ("CACHE_MONTH=" + $(date '+%b %Y')) >> $env:GITHUB_ENV
       - name: Cache MinGW installation
         id: cache-mingw
-        uses: actions/cache@v3
-        if: matrix.platform == 'win-gcc'
+        uses: actions/cache@v4
         with:
           path: C:\ProgramData\chocolatey\lib\mingw
           key: ${{ env.CACHE_MONTH }}
       - name: Set up MinGW
-        uses: egor-tensin/setup-mingw@v2
-        if: matrix.platform == 'win-gcc'
+        uses: egor-tensin/setup-mingw@v2.2.0
         with:
+          version: 12.2.0 
           platform: x64
       - name: CMake
         run: rake cmake
@@ -72,8 +126,8 @@ jobs:
         run: rake package
         if: github.event_name == 'push'
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform }}-${{ matrix.lib-type }}-64-${{ matrix.graphics-api }}-rel
+          name: win-gcc-${{ matrix.lib-type }}-64-${{ matrix.graphics-api }}-rel
           path: build/ci/*.zip
         if: github.event_name == 'push'

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2008-2022 the Urho3D project.
+# Copyright (c) 2022-2024 the U3D project.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -230,7 +231,7 @@ endif ()
 
 # Define generated source files
 if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/librevision.h)
-    execute_process (COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/librevision.h -P cmake/Modules/GetUrhoRevision.cmake
+    execute_process (COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/librevision.h -P ${CMAKE_SOURCE_DIR}/cmake/Modules/GetUrhoRevision.cmake
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_QUIET ERROR_QUIET)
 endif ()
 set (URHO3D_DEPS ${STATIC_LIBRARY_TARGETS})
@@ -244,7 +245,7 @@ if (TARGET LuaJIT_universal)
 endif ()
 set_source_files_properties (${SYMBOLIC_SOURCES} PROPERTIES SYMBOLIC TRUE)
 add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/librevision.h
-    COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/librevision.h.new -P cmake/Modules/GetUrhoRevision.cmake
+    COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/librevision.h.new -P ${CMAKE_SOURCE_DIR}/cmake/Modules/GetUrhoRevision.cmake
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/librevision.h.new ${CMAKE_CURRENT_BINARY_DIR}/librevision.h
     COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/librevision.h.new
     DEPENDS ${URHO3D_DEPS} ${CMAKE_SOURCE_DIR}/cmake/Modules/GetUrhoRevision.cmake

--- a/cmake/Modules/FindDirectX.cmake
+++ b/cmake/Modules/FindDirectX.cmake
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2008-2022 the Urho3D project.
+# Copyright (c) 2022-2024 the U3D project.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -240,5 +241,8 @@ foreach (COMPONENT DInput DSound XInput)
 endforeach ()
 set (CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVED})
 
-include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (DirectX REQUIRED_VARS HAVE_DIRECTX HANDLE_COMPONENTS FAIL_MESSAGE ${FAIL_MESSAGE})
+# do we need this for MINGW ?
+if (NOT MINGW)
+    include (FindPackageHandleStandardArgs)
+    find_package_handle_standard_args (DirectX REQUIRED_VARS HAVE_DIRECTX HANDLE_COMPONENTS FAIL_MESSAGE ${FAIL_MESSAGE})
+endif()

--- a/cmake/Modules/UrhoCommon.cmake
+++ b/cmake/Modules/UrhoCommon.cmake
@@ -508,6 +508,9 @@ if (WIN32 AND NOT CMAKE_PROJECT_NAME MATCHES ^Urho3D-ExternalProject-)
     endif ()
 endif ()
 
+# SDL_LIBS : allow to link against Urho3D the external LIBS from SDL
+set (SDL_LIBS)
+
 # Platform and compiler specific options
 set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -894,16 +897,20 @@ macro (define_dependency_libs TARGET)
             list (APPEND LIBS dl log android)
         else ()
             # Linux
-            if (${TARGET} MATCHES SDL)
-                # set external libraries dependencies for SDL and add them later to URHO3D
-                set (URHO3D_LIBRARIES ${EXTRA_LIBS} PARENT_SCOPE)
-            elseif (NOT WEB)                
+            if (NOT WEB)
                 list (APPEND LIBS dl m rt)
             endif ()
             if (RPI)
                 list (APPEND ABSOLUTE_PATH_LIBS ${VIDEOCORE_LIBRARIES})
             endif ()
         endif ()
+    endif ()
+
+    # Set extra dependencies from SDL and add them later to URHO3D
+    # Android : need OpenSLES
+    # Linux   : may need Wayland and X11 (only for X11-static)
+    if (${TARGET} MATCHES SDL)
+       set (SDL_LIBS ${EXTRA_LIBS} PARENT_SCOPE)
     endif ()
 
     # ThirdParty/Civetweb external dependency
@@ -1779,7 +1786,9 @@ macro (_setup_target)
     include_directories (${INCLUDE_DIRS})
     # Link libraries
     define_dependency_libs (${TARGET_NAME})
-    target_link_libraries (${TARGET_NAME} ${ABSOLUTE_PATH_LIBS} ${LIBS})
+    # Needed external libraries for the current target (SDL_LIBS added)
+    target_link_libraries (${TARGET_NAME} ${ABSOLUTE_PATH_LIBS} ${SDL_LIBS} ${LIBS})
+    set (SDL_LIBS)
     # Enable PCH if requested
     if (${TARGET_NAME}_HEADER_PATHNAME)
         enable_pch (${${TARGET_NAME}_HEADER_PATHNAME})

--- a/rakefile
+++ b/rakefile
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2008-2022 the Urho3D project.
+# Copyright (c) 2022-2024 the U3D project.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -42,12 +43,12 @@ task :cmake => [:init] do
       system 'bash', '-c', 'rm -rf ~/.{ccache,gradle}' or abort 'Failed to clear the build cache'
     end
   end
-  next if ENV['PLATFORM'] == 'android' || (Dir.exists?(build_tree) and not ARGV.include?('cmake'))
+  next if ENV['PLATFORM'] == 'android' || (Dir.exist?(build_tree) and not ARGV.include?('cmake'))
   ['CMAKE_INSTALL_PREFIX', 'URHO3D_HOME'].each { |var|
     if ENV[var] == 'system'
       ENV.delete(var)
     elsif !ENV[var]
-      ENV[var] = install_dir if var == 'CMAKE_INSTALL_PREFIX' || Dir.exists?(install_dir)
+      ENV[var] = install_dir if var == 'CMAKE_INSTALL_PREFIX' || Dir.exist?(install_dir)
     end
   }
   script = "script/cmake_#{ENV['GENERATOR']}#{ENV['OS'] ? '.bat' : '.sh'}"
@@ -152,7 +153,7 @@ task :new, [:name, :parent_dir, :use_copy] => [:init] do |_, args|
   parent_dir = verify_path(args[:parent_dir])
   dir = "#{parent_dir}/#{name}"
   use_copy = args[:use_copy] || dockerized?
-  abort "The directory '#{dir}' already exists!" if Dir.exists?(dir)
+  abort "The directory '#{dir}' already exist!" if Dir.exist?(dir)
   puts "Creating a new project in #{dir}..."
   func = FileUtils.method(use_copy ? :cp_r : :ln_s)
   source_tree(name).split("\n").each do |it|
@@ -292,7 +293,7 @@ task :init do
     unless ENV['PLATFORM']
       if /x86/ =~ `uname -m`
         ENV['PLATFORM'] = 'linux'
-      elsif Dir.exists?('/opt/vc')
+      elsif Dir.exist?('/opt/vc')
         ENV['PLATFORM'] = 'rpi'
       else
         ENV['PLATFORM'] = 'arm'
@@ -413,7 +414,7 @@ def default_path
 end
 
 def dockerized?
-  File.exists?('/entrypoint.sh')
+  File.exist?('/entrypoint.sh')
 end
 
 def install_dir
@@ -428,7 +429,7 @@ def verify_path(path, auto_create = false)
   require 'pathname'
   begin
     expanded_path = File.expand_path(path)
-    FileUtils.mkdir_p(expanded_path) if (auto_create && !Dir.exists?(expanded_path))
+    FileUtils.mkdir_p(expanded_path) if (auto_create && !Dir.exist?(expanded_path))
     Pathname.new(expanded_path).realdirpath.to_s
   rescue
     abort "The specified path '#{path}' is invalid!"
@@ -440,7 +441,7 @@ def first_match(regex, from)
     if from.instance_of?(Array)
       array = from
     else
-      array = File.exists?(from) ? File.readlines(from) : from.split("\n")
+      array = File.exist?(from) ? File.readlines(from) : from.split("\n")
     end
     array.grep(regex).first.match(regex).captures.first
   rescue


### PR DESCRIPTION
- Split the windows workflow in 2 jobs (vs and gcc)
- Mingw : Change to egor-tensin/setup-mingw@v2.2.0 and use gcc 12.2.0 to solve the issue (according to https://github.com/egor-tensin/setup-mingw/issues/17)
- Mingw : Add environnement: MINGW_SYSROOT explicitly
- Mingw : Remove FindPackageHandleStandardArgs
- Patch rakefile (replace deprecated "exists" function by "exist")