### PR TITLE
Send events on Animatable animation add/remove

### DIFF
--- a/Source/Urho3D/Scene/Animatable.cpp
+++ b/Source/Urho3D/Scene/Animatable.cpp
@@ -373,7 +373,14 @@ void Animatable::SetAttributeAnimation(const String& name, ValueAnimation* attri
         attributeAnimationInfos_[name] = new AttributeAnimationInfo(this, *attributeInfo, attributeAnimation, wrapMode, speed);
 
         if (!info)
+        {
             OnAttributeAnimationAdded();
+
+            using namespace AttributeAnimationAdded;
+            VariantMap& eventData = GetEventDataMap();
+            eventData[P_ATTRIBUTEANIMATIONNAME] = name;
+            SendEvent(E_ATTRIBUTEANIMATIONADDED, eventData);
+        }
     }
     else
     {
@@ -386,6 +393,11 @@ void Animatable::SetAttributeAnimation(const String& name, ValueAnimation* attri
 
         attributeAnimationInfos_.Erase(name);
         OnAttributeAnimationRemoved();
+
+        using namespace AttributeAnimationRemoved;
+        VariantMap& eventData = GetEventDataMap();
+        eventData[P_ATTRIBUTEANIMATIONNAME] = name;
+        SendEvent(E_ATTRIBUTEANIMATIONREMOVED, eventData);
     }
 }
 

--- a/Source/Urho3D/Scene/SceneEvents.h
+++ b/Source/Urho3D/Scene/SceneEvents.h
@@ -72,14 +72,14 @@ URHO3D_EVENT(E_ATTRIBUTEANIMATIONUPDATE, AttributeAnimationUpdate)
     URHO3D_PARAM(P_TIMESTEP, TimeStep);            // float
 }
 
-/// Attribute animation added to object animation.
+/// Attribute animation added to object animation, or directly to the animatable.
 URHO3D_EVENT(E_ATTRIBUTEANIMATIONADDED, AttributeAnimationAdded)
 {
     URHO3D_PARAM(P_OBJECTANIMATION, ObjectAnimation);               // Object animation pointer
     URHO3D_PARAM(P_ATTRIBUTEANIMATIONNAME, AttributeAnimationName); // String
 }
 
-/// Attribute animation removed from object animation.
+/// Attribute animation removed from object animation, or directly from the animatable.
 URHO3D_EVENT(E_ATTRIBUTEANIMATIONREMOVED, AttributeAnimationRemoved)
 {
     URHO3D_PARAM(P_OBJECTANIMATION, ObjectAnimation);               // Object animation pointer


### PR DESCRIPTION
This is a "non-destructive" version of PR #75 .
It makes Animatables send E_ATTRIBUTEANIMATIONREMOVED and E_ATTRIBUTEANIMATIONADDED when animations are added/removed directly to/from Animatables. Currently, those events are only being sent by ObjectAnimations.