### PR TITLE
CI Linux and QA update

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   android:
     name: 📱
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   docs:
     name: 📖 Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
     env:
@@ -34,13 +34,13 @@ jobs:
       LLVM_ENABLE_ASSERTIONS: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - name: Source checksum
         id: source_checksum
         run: rake source_checksum
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             build/cache/.ccache
@@ -54,7 +54,7 @@ jobs:
       - name: Documentation
         run: script/dockerized.sh ${PLATFORM/-*} rake doc
       - name: Deploy Documentation to Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./Docs/html/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   linux:
     name: 🐧
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   qa:
     name: 🔬 Quality Assurance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
     env:
@@ -23,13 +23,13 @@ jobs:
       LLVM_ENABLE_ASSERTIONS: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - name: Source checksum
         id: source_checksum
         run: rake source_checksum
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             build/cache/.ccache

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -18,6 +18,7 @@ jobs:
       LIB_TYPE: shared
       ARCH: 64
       DBE_TAG: master
+      URHO3D_DOCS: 1
       USE_CCACHE: 1
       LLVM_USE_SPLIT_DWARF: 1
       LLVM_ENABLE_ASSERTIONS: 1

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   web:
     name: Web
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
- Use Ubuntu 22.04 instead of Ubuntu-latest which will be updated to 24.04 soon.
- QA : Use cache v4 and add URHO3D_DOCS define.
