### PR TITLE
Fix find home environment var not being used if set to build tree

### DIFF
--- a/cmake/Urho3D.cmake
+++ b/cmake/Urho3D.cmake
@@ -110,7 +110,8 @@ endif ()
 
 # Check URHO3D_HOME
 if (NOT DEFINED URHO3D_HOME AND DEFINED ENV{URHO3D_HOME} AND
-        EXISTS $ENV{URHO3D_HOME}/cmake/Modules/UrhoCommon.cmake)
+        (EXISTS $ENV{URHO3D_HOME}/cmake/Modules/UrhoCommon.cmake) OR
+		(EXISTS $ENV{URHO3D_HOME}/include/Urho3D/Urho3DAll.h))
     set (URHO3D_HOME $ENV{URHO3D_HOME})
     message ("URHO3D_HOME defined from environment variable: ${URHO3D_HOME}")
 endif ()


### PR DESCRIPTION
Currently, the URHO3D_HOME environment variable will only be used if it is set to a "SDK" type of directory, where both source files and build outputs are in. If the variable is set to a directory where only the build tree/outputs are, it won't be recognized by the cmake script