### PR TITLE
UIElement save: remove all data identical to style

### DIFF
--- a/Source/Urho3D/UI/UIElement.cpp
+++ b/Source/Urho3D/UI/UIElement.cpp
@@ -2014,6 +2014,48 @@ bool UIElement::FilterUIStyleAttributes(XMLElement& dest, const XMLElement& styl
         }
     }
 
+    // remove all data identical to style data
+    XMLElement destAttrChild = dest.GetChild("attribute");
+    static XPathQuery matchXPathQuery("./attribute[@name=$attributeName and @value=$attributeValue]",
+                                      "attributeName:String, attributeValue:String");
+
+    if (styleElem.HasChild("attribute"))
+    {
+        while (destAttrChild)
+        {
+            const String& attrName = destAttrChild.GetAttribute("name");
+            const String& attrValue = destAttrChild.GetAttribute("value");
+            if (!attrName.Empty() && !attrValue.Empty())
+            {
+                // find entry in style with same name
+                if (!matchXPathQuery.SetVariable("attributeName", attrName))
+                    return false;
+
+                if (!matchXPathQuery.SetVariable("attributeValue", attrValue))
+                    return false;
+
+                XMLElement styleAttrChild = styleElem.SelectSinglePrepared(matchXPathQuery);
+
+                if (styleAttrChild)
+                {
+                    XMLElement nextAttrChildDest = destAttrChild.GetNext("attribute");
+
+                    if (!destAttrChild.Remove())
+                    {
+                        return false;
+                    }
+
+                    destAttrChild = nextAttrChildDest;
+                    continue;
+                }
+            }
+
+            destAttrChild = destAttrChild.GetNext("attribute");
+        }
+
+    }
+    
+
     return true;
 }
 


### PR DESCRIPTION
Currently, when UI is saved, most, if not all attributes, are written to the output XML, even if those attributes are identical to the applied style at the moment of saving. This makes it so that, if we change the style file afterwards, these changes won't be applied to the saved file, because the no-longer-identical data in the UI XML file takes precedence.

This commit changes that: at the moment of the save, the output XML is compared to the style file, and identical attributes are removed, so that changing the style file actually changes the UI, unless attributes are explicitly made different from what is in the style file.

This doesn't affect already saved XMLs... unless they're saved again