### PR TITLE
Add Windows build script and minor CMake improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@
 # Set CMake minimum version
 cmake_minimum_required (VERSION 3.10.2)
 
+# Policy CMP0177 is not set: install() DESTINATION paths are normalized. 
+cmake_policy(SET CMP0177 NEW)
+
 # Set project name
 project (Urho3D)
 

--- a/GenerateProjectFiles_VS22.bat
+++ b/GenerateProjectFiles_VS22.bat
@@ -1,0 +1,10 @@
+@echo off
+REM Change to the directory where this script is located
+cd /d %~dp0
+
+if not exist "build" (
+    mkdir build
+)
+cd build
+cmake -G "Visual Studio 17 2022" ..
+pause


### PR DESCRIPTION
This pull request introduces a new batch script (**GenerateProjectFiles_VS22.bat**) that automates the creation of a build directory and runs CMake with the Visual Studio 2022 generator. These changes streamline the setup process for Windows users by eliminating the need to manually create the build folder and invoke CMake commands each time. Additionally, this helps new contributors get up and running faster, reduces human error, and provides a more consistent development workflow.

What was done:
Created build.bat to automatically create a build folder and run **cmake -G "Visual Studio 17 2022" ..**
Ensured the script operates relative to the batch file’s directory, making it portable and easy to use.

Why it was done:
Simplifies the build process for Windows developers.
Encourages more contributions by removing repetitive steps and potential user errors.
Aims to restore and improve project workflow after prior disruptions, ensuring a smooth developer experience.

Please let me know if there are any suggested changes or additional improvements you’d like to see!