### PR TITLE
Some warning fixes

### DIFF
--- a/Source/Urho3D/AngelScript/ScriptInstance.cpp
+++ b/Source/Urho3D/AngelScript/ScriptInstance.cpp
@@ -752,7 +752,7 @@ void ScriptInstance::GetScriptAttributes()
             {
                 info.mode_ |= AM_FILE;
                 info.name_ = name;
-                info.ptr_ = (void*)i;
+                info.ptr_ = (void*)(asPWORD)i;
                 attrTemplate->Push(info);
             }
         }
@@ -763,7 +763,7 @@ void ScriptInstance::GetScriptAttributes()
     {
         attributeInfos_.Push(attrTemplate->At(i));
         AttributeInfo& back = attributeInfos_.Back();
-        back.ptr_ = scriptObject_->GetAddressOfProperty((size_t)back.ptr_);
+        back.ptr_ = scriptObject_->GetAddressOfProperty((asPWORD)back.ptr_);
         int t = 1;
     }
 }

--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -1171,7 +1171,7 @@ private:
     static void CopyElements(T* dest, const T* src, unsigned count)
     {
         if (count)
-            memcpy(dest, src, count * sizeof(T));
+            memcpy((void*)dest, (const void*)src, count * sizeof(T));
     }
 };
 

--- a/Source/Urho3D/Core/Variant.cpp
+++ b/Source/Urho3D/Core/Variant.cpp
@@ -133,7 +133,7 @@ Variant& Variant::operator =(const Variant& rhs)
         break;
 
     default:
-        memcpy(&value_, &rhs.value_, sizeof(VariantValue));     // NOLINT(bugprone-undefined-memory-manipulation)
+        memcpy((void*)&value_, (const void*)&rhs.value_, sizeof(VariantValue));     // NOLINT(bugprone-undefined-memory-manipulation)
         break;
     }
 

--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -547,8 +547,9 @@ String FileSystem::GetCurrentDir() const
 #else
     char path[MAX_PATH];
     path[0] = 0;
-    getcwd(path, MAX_PATH);
-    return AddTrailingSlash(String(path));
+    if (getcwd(path, MAX_PATH) != NULL)
+        return AddTrailingSlash(String(path));
+    return String::EMPTY;
 #endif
 }
 
@@ -718,8 +719,9 @@ String FileSystem::GetProgramDir() const
     memset(exeName, 0, MAX_PATH);
     pid_t pid = getpid();
     String link = "/proc/" + String(pid) + "/exe";
-    readlink(link.CString(), exeName, MAX_PATH);
-    return GetPath(String(exeName));
+    if (readlink(link.CString(), exeName, MAX_PATH) != -1)
+        return GetPath(String(exeName));
+    return String::EMPTY;
 #else
     return GetCurrentDir();
 #endif

--- a/Source/Urho3D/Resource/XMLElement.cpp
+++ b/Source/Urho3D/Resource/XMLElement.cpp
@@ -228,7 +228,7 @@ XMLElement XMLElement::SelectSingle(const String& query, pugi::xpath_variable_se
         return XMLElement();
 
     const pugi::xml_node& node = xpathNode_ ? xpathNode_->node() : pugi::xml_node(node_);
-    pugi::xpath_node result = node.select_single_node(query.CString(), variables);
+    pugi::xpath_node result = node.select_node(query.CString(), variables);
     return XMLElement(file_, nullptr, &result, 0);
 }
 
@@ -238,7 +238,7 @@ XMLElement XMLElement::SelectSinglePrepared(const XPathQuery& query) const
         return XMLElement();
 
     const pugi::xml_node& node = xpathNode_ ? xpathNode_->node() : pugi::xml_node(node_);
-    pugi::xpath_node result = node.select_single_node(*query.GetXPathQuery());
+    pugi::xpath_node result = node.select_node(*query.GetXPathQuery());
     return XMLElement(file_, nullptr, &result, 0);
 }
 

--- a/Source/Urho3D/Resource/XMLFile.cpp
+++ b/Source/Urho3D/Resource/XMLFile.cpp
@@ -207,7 +207,7 @@ void XMLFile::Patch(const XMLElement& patchElement)
         }
 
         // Only select a single node at a time, they can use xpath to select specific ones in multiple otherwise the node set becomes invalid due to changes
-        pugi::xpath_node original = document_->select_single_node(sel.value());
+        pugi::xpath_node original = document_->select_node(sel.value());
         if (!original)
         {
             URHO3D_LOGERROR("XML Patch failed with bad select: {}.", sel.value());


### PR DESCRIPTION
 These changes correct the causes of certain warnings:

- AngelScript: Added explicit cast (asPWORD is the one to use to manage ptr size)

- XMLElement, XMLFile : pugi::select_single_node replaced by pugi::select_node

- FileSystem : correctly handle the return value of certain Unix/Linux methods.

- Container: Added explicit void* cast for memcpy