### PR TITLE
Bullet warning patch

### DIFF
--- a/Source/ThirdParty/Bullet/CMakeLists.txt
+++ b/Source/ThirdParty/Bullet/CMakeLists.txt
@@ -43,5 +43,10 @@ set (INCLUDE_DIRS src)
 # Setup target
 setup_library ()
 
+if (MSVC)
+    # Silence MSVC 'conversion' warnings for the target 'Bullet'
+    target_compile_options(Bullet PRIVATE "/wd4244" "/wd4267")
+endif()
+
 # Install headers for building and using the Urho3D library (install dependency for Urho3D/Physics/PhysicsWorld.h, Urho3D/Physics/RigidBody.h, and Urho3D/Physics/PhysicsUtils.h)
 install_header_files (DIRECTORY src/ DESTINATION ${DEST_INCLUDE_DIR}/ThirdParty/Bullet FILES_MATCHING PATTERN *.h)  # Note: the trailing slash is significant

--- a/Source/ThirdParty/Bullet/src/LinearMath/btAlignedObjectArray.h
+++ b/Source/ThirdParty/Bullet/src/LinearMath/btAlignedObjectArray.h
@@ -217,12 +217,15 @@ public:
 			{
 				reserve(newsize);
 			}
+
 #ifdef BT_USE_PLACEMENT_NEW
-			for (int i = curSize; i < newsize; i++)
+			// U3D fix : only placement new if newsize > 0
+			if (newsize)
 			{
-				new (&m_data[i]) T(fillData);
+				for (int i = curSize; i < newsize; i++)
+					new (&m_data[i]) T(fillData);
 			}
-#endif  //BT_USE_PLACEMENT_NEW
+#endif  //BT_USE_PLACEMENT_NEW			
 		}
 
 		m_size = newsize;


### PR DESCRIPTION
- MSVC : disable warnings C4244 and C4267 because they yield too much.

- Fix warning if required size is zero with placement new (in btAlignedObjectArray.h)