### PR TITLE
Urho3D.cmake : fetch u3d source from git repository

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ include (UrhoCommon)
 
 # Ensure Compatibility if using old UrhoCommon module
 if (NOT URHO3D_ROOT_DIR)
-    message (WARNING "You're using old cmake modules !/n
-        new urho3d cmake modules are available for better urho3d/user project separation")
+    message (WARNING "You're using old cmake modules !")
+    message (WARNING "New urho3d cmake modules are available for better urho3d/user project separation")
     set (URHO3D_ROOT_DIR ${CMAKE_SOURCE_DIR})
     set (URHO3D_SOURCE_DIR ${CMAKE_SOURCE_DIR}/Source)
     set (URHO3D_BUILD_DIR ${CMAKE_BINARY_DIR})    

--- a/cmake/UrhoDiscover.cmake
+++ b/cmake/UrhoDiscover.cmake
@@ -162,7 +162,7 @@ endfunction ()
 # Launches a search process starting at "search_path" to find the filename "filename" inside a sub-folder "dirname"
 #   (excluding all sub-folders listed in "excludepaths" from the search for Unix-like systems only)
 function (urho_find_process search_path filename dirname excludepaths results errors)
-    message (" .. Searching for Urho3D directories in path = ${search_path} (this may take some time)")
+    message (DEBUG " .. Searching for Urho3D directories in path = ${search_path}")
     if (MSVC)
         string(REPLACE "/" "\\" dirname "${dirname}")
         execute_process (
@@ -217,7 +217,7 @@ macro (urho_find_sources_dirs)
             endif ()
         endforeach ()
     endif ()        
-    message (" ... num sources = ${NUM_SOURCE_DIRS}")
+    message (DEBUG " ... num sources = ${NUM_SOURCE_DIRS}")
 endmacro ()
 
 # Search in ${PROJECTNAME}_URHO3D_SEARCH_PATH for all occurrences of include/Urho3D/Urho3D.h
@@ -260,7 +260,7 @@ macro (urho_find_builds_dirs)
             endif ()
         endforeach ()
     endif ()
-    message (" ... num builds = ${NUM_SOURCE_DIRS}")
+    message (DEBUG " ... num builds = ${NUM_SOURCE_DIRS}")
 endmacro ()
 
 # Generate the tag list for ${PROJECTNAME}_URHO3D_SELECT
@@ -331,6 +331,17 @@ macro (unset_cache_variables_without prefix)
     endforeach ()
 endmacro ()
 
+macro (urho_update_cached_dirs)
+    unset (${PROJECTNAME}_URHO3D_DIRS CACHE)
+    unset (${PROJECTNAME}_URHO3D_TAGS CACHE)
+    set (${PROJECTNAME}_URHO3D_DIRS ${${PROJECTNAME}_URHO3D_DIRS} CACHE INTERNAL "All available Urho3D directories")
+    set (${PROJECTNAME}_URHO3D_TAGS ${${PROJECTNAME}_URHO3D_TAGS} CACHE INTERNAL "All available Urho3D tags")
+    set (${PROJECTNAME}_URHO3D_SELECT "" CACHE STRING "Urho3D source/build tree selection" FORCE)
+    set_property (CACHE ${PROJECTNAME}_URHO3D_SELECT PROPERTY STRINGS ${${PROJECTNAME}_URHO3D_TAGS})
+endmacro ()
+
+
+
 set (${PROJECTNAME}_URHO3D_SEARCH_PATH "" CACHE PATH "Root path for searching Urho3D")
 if (NOT ${PROJECTNAME}_URHO3D_SEARCH_PATH)
     if (URHO3D_SEARCH_PATH)
@@ -352,6 +363,7 @@ else ()
 endif ()
 
 if (SEARCH_URHO3D_ENABLE)
+    message (STATUS "URHO3D_DISCOVER ... search (this may take some time) ...")
     unset (${PROJECTNAME}_URHO3D_DIRS)
     unset (${PROJECTNAME}_URHO3D_DIRS CACHE)
     unset (${PROJECTNAME}_URHO3D_TAGS)
@@ -361,19 +373,16 @@ if (SEARCH_URHO3D_ENABLE)
 
     if (${PROJECTNAME}_URHO3D_DIRS)
         list (SORT ${PROJECTNAME}_URHO3D_DIRS)
-        urho_generate_tags_list (taglist)
+        urho_generate_tags_list (${PROJECTNAME}_URHO3D_TAGS)
     endif ()
 
     set (num_tags 0)
-    if (taglist)
-        list (LENGTH taglist num_tags)
+    if (${PROJECTNAME}_URHO3D_TAGS)
+        list (LENGTH ${PROJECTNAME}_URHO3D_TAGS num_tags)
     endif ()
     message (" ... Found ${num_tags} Urho3D directories!")
 
-    set (${PROJECTNAME}_URHO3D_DIRS ${${PROJECTNAME}_URHO3D_DIRS} CACHE INTERNAL "All available Urho3D directories")
-    set (${PROJECTNAME}_URHO3D_TAGS ${taglist} CACHE INTERNAL "All available Urho3D tags")
-    set (${PROJECTNAME}_URHO3D_SELECT "" CACHE STRING "Urho3D source/build tree selection" FORCE)
-    set_property (CACHE ${PROJECTNAME}_URHO3D_SELECT PROPERTY STRINGS ${${PROJECTNAME}_URHO3D_TAGS})
+    urho_update_cached_dirs()
 endif ()
 
 # Update the Urho3D directory selection


### PR DESCRIPTION
These commits add the ability to fetch u3d from a git repository:
- The fetch condition can be set with var. URHO3D_FETCH_CONDITION ("always", "never", "u3d_not_found")
- By default, "u3d_not_found": if no u3d content is found, Urho3D.cmake fetches u3d sources from the u3d community repository.
- A different repository can be used by defining the vars GIT_U3D_REPO and GIT_U3D_TAG.

If you prefer, you can use "git submodule add ..." to add u3d as a submodule from a git repository.

In all cases, be sure to add cmake/Urho3D.cmake to your project root folder. UrhoDiscover.cmake is optional.