### PR TITLE
Android Workflow : fix paths for uploading artifacts (solve #100)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -76,10 +76,11 @@ jobs:
           name: android-${{ matrix.lib-type }}-all-both
           path: |
             build/ci/*.tar.gz
-            android/urho3d-lib/build/distributions/*.aar
-            android/urho3d-lib/build/distributions/*.zip
-            android/urho3d-lib/build/libs/*.jar
             build/*.out
+            android/urho3d-lib/build/outputs/aar/*.aar
+            android/urho3d-lib/build/libs/*.jar
+            android/launcher-app/build/outputs/apk/debug/*.apk
+            android/launcher-app/build/outputs/apk/release/*.apk                        
         if: github.event_name == 'push'
         continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Publish


### PR DESCRIPTION
Update for Android workflow:
- Changed the paths where apks and aars are generated.