### PR TITLE
FindUrho3D : Fix missing Thirdparty Bullet and Lua include dirs for user projects.

### DIFF
--- a/cmake/Modules/FindUrho3D.cmake
+++ b/cmake/Modules/FindUrho3D.cmake
@@ -163,15 +163,6 @@ else ()
             get_filename_component (URHO3D_HOME ${URHO3D_INCLUDE_DIRS} DIRECTORY)
         endif ()
         list (APPEND URHO3D_INCLUDE_DIRS ${URHO3D_BASE_INCLUDE_DIR}/ThirdParty)
-        if (URHO3D_PHYSICS)
-            list (APPEND URHO3D_INCLUDE_DIRS ${URHO3D_BASE_INCLUDE_DIR}/ThirdParty/Bullet)
-        endif ()
-        if (URHO3D_LUA)
-            list (APPEND URHO3D_INCLUDE_DIRS ${URHO3D_BASE_INCLUDE_DIR}/ThirdParty/Lua${JIT})
-        endif ()
-        # Intentionally do not cache the URHO3D_VERSION as it has potential to change frequently
-        file (STRINGS "${URHO3D_BASE_INCLUDE_DIR}/librevision.h" URHO3D_VERSION REGEX "^const char\\* revision=\"[^\"]*\".*$")
-        string (REGEX REPLACE "^const char\\* revision=\"([^\"]*)\".*$" \\1 URHO3D_VERSION "${URHO3D_VERSION}")      # Stringify to guard against empty variable
     endif ()
 
     # Set URHO3D_LIBRARIES
@@ -330,7 +321,8 @@ else ()
         set (AUTO_DISCOVER_VARS
             URHO3D_STATIC_DEFINE URHO3D_OPENGL URHO3D_D3D11 URHO3D_SSE URHO3D_DATABASE_ODBC 
             URHO3D_DATABASE_SQLITE URHO3D_LUAJIT URHO3D_TESTING CLANG_PRE_STANDARD URHO3D_STATIC_RUNTIME 
-            URHO3D_SPINE WAYLAND_CLIENT
+            URHO3D_SPINE WAYLAND_CLIENT URHO3D_ANGELSCRIPT URHO3D_LUA URHO3D_LUAJIT URHO3D_IK URHO3D_NAVIGATION URHO3D_NETWORK 
+            URHO3D_PHYSICS URHO3D_PHYSICS2D URHO3D_URHO2D URHO3D_WEBP URHO3D_LOGGING URHO3D_PROFILING URHO3D_TRACY_PROFILING
         )
 
         if (EXPORT_HEADER MATCHES "#define AS_MAX_PORTABILITY")
@@ -362,11 +354,23 @@ else ()
             set (${VAR} ${AUTO_DISCOVERED_${VAR}})            
         endforeach ()
 
+        # Append Physics And Lua Thirdparty include dirs if their option are enabled
+        if (URHO3D_PHYSICS)
+            list (APPEND URHO3D_INCLUDE_DIRS ${URHO3D_BASE_INCLUDE_DIR}/ThirdParty/Bullet)
+        endif ()
+        if (URHO3D_LUA)
+            list (APPEND URHO3D_INCLUDE_DIRS ${URHO3D_BASE_INCLUDE_DIR}/ThirdParty/Lua${JIT})
+        endif ()
+
         # If both the non-debug and debug version of the libraries are found on Windows platform then use them both
         if (URHO3D_LIBRARIES_REL AND URHO3D_LIBRARIES_DBG)
             set (URHO3D_LIBRARIES ${URHO3D_LIBRARIES_REL} ${URHO3D_LIBRARIES_DBG})
         endif ()
     endif ()
+
+    # Intentionally do not cache the URHO3D_VERSION as it has potential to change frequently
+    file (STRINGS "${URHO3D_BASE_INCLUDE_DIR}/librevision.h" URHO3D_VERSION REGEX "^const char\\* revision=\"[^\"]*\".*$")
+    string (REGEX REPLACE "^const char\\* revision=\"([^\"]*)\".*$" \\1 URHO3D_VERSION "${URHO3D_VERSION}")      # Stringify to guard against empty variable
 
     # Restore CMake global settings
     if (CMAKE_FIND_LIBRARY_SUFFIXES_SAVED)


### PR DESCRIPTION
This modification contradicts the U3D convention "Third party libraries are included as source for the build process. However, they are hidden from the public API as completely as possible.", but it already existed in the old previous release, so this exception to the rule is to be maintained.

- Reorder some blocks : First restore options URHO3D_PHYSICS, URHO3D_LUA (from auto_discover vars) and then, if option is enabled, append the third party to URHO3D_INCLUDE_DIRS.

### Note: 

The refactoring of the build system introduces the separation of build options between the U3D project and the user project, which implies that the u3d build options are neither shown nor modifiable in cmake-gui when using U3D as a prebuilt library in your project. However, these build options are defined for user projects in the Urho3D header files. It should not break anything.

If you encounter problems with this, let me know!