### PR TITLE
Editor load scene: don't remove res path if set to remember

### DIFF
--- a/bin/Data/Scripts/Editor/EditorScene.as
+++ b/bin/Data/Scripts/Editor/EditorScene.as
@@ -200,8 +200,8 @@ bool LoadScene(const String&in fileName)
 
     // Add the scene's resource path in case it's necessary
     String newScenePath = GetPath(fileName);
-    if (!rememberResourcePath || !sceneResourcePath.StartsWith(newScenePath, false))
-        SetResourcePath(newScenePath);
+    if (!sceneResourcePath.StartsWith(newScenePath, false))
+        SetResourcePath(newScenePath, true, rememberResourcePath);
 
     suppressSceneChanges = true;
     sceneModified = false;


### PR DESCRIPTION
This adds support to the following use case:
- built u3d player in generic u3d repo, use this player to open the editor
- use editor's "set resource path" option to point to a separate project
- open a scene from separate project

Without this change, the procedure above would cause the resource path to be reset to the generic u3d repo, making the scene not load correctly