### PR TITLE
GCC 14/15 compilation error fix in SDL_pipewire.c

### DIFF
--- a/Source/ThirdParty/SDL/src/audio/pipewire/SDL_pipewire.c
+++ b/Source/ThirdParty/SDL/src/audio/pipewire/SDL_pipewire.c
@@ -590,7 +590,7 @@ static void node_event_info(void *object, const struct pw_node_info *info)
 
         /* Need to parse the parameters to get the sample rate */
         for (i = 0; i < info->n_params; ++i) {
-            pw_node_enum_params(node->proxy, 0, info->params[i].id, 0, 0, NULL);
+            pw_node_enum_params((struct pw_node*)node->proxy, 0, info->params[i].id, 0, 0, NULL);
         }
 
         hotplug_core_sync(node);


### PR DESCRIPTION
 casting node->proxy parameter to (struct pw_node*)node->proxy in pw_node_enum_params function