### PR TITLE
2D animSprite: support multiple spritesheets

### DIFF
--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -2670,7 +2670,7 @@ Urho2D provides a handful of classes for loading/drawing the kind of sprite requ
 
 \section Urho2D_Animated Animated sprites
 
-Workflow for creating animated sprites in Urho2D relies on Spriter (c). Spriter is a crossplatform tool for creating 2D animations. It comes both as an almost fully featured free version and a more advanced 'pro' version. Free version is available at https://brashmonkey.com/spriter-pro/. To get started, scml files from bin/Data/Urho2D folder can be loaded in Spriter. Note that although currently Spriter doesn't support spritesheets/texture atlases, Urho2D does: you just have to use the same name for your scml file and your spritesheet's xml file (see \ref Urho2D_Static_Sprites "Static sprites" below for details on how to generate this file). Example 33_Urho2DSpriterAnimation is a good demonstration of this feature (scml file and xml spritesheet are both named 'imp' to instruct Urho2D to use the atlas instead of the individual files). You could remove every image files in the 'imp' folder and just keep 'imp_all.png' to test it out. However, keep your individual image files as they are still required if you want to later edit your scml project in Spriter.
+Workflow for creating animated sprites in Urho2D relies on Spriter (c). Spriter is a crossplatform tool for creating 2D animations. It comes both as an almost fully featured free version and a more advanced 'pro' version. Free version is available at https://brashmonkey.com/spriter-pro/. To get started, scml files from bin/Data/Urho2D folder can be loaded in Spriter. Note that although currently Spriter doesn't support spritesheets/texture atlases, Urho2D does: you just have to use the same name for your scml file and your spritesheet's xml file (see \ref Urho2D_Static_Sprites "Static sprites" below for details on how to generate this file). Example 33_Urho2DSpriterAnimation is a good demonstration of this feature (scml file and xml spritesheet are both named 'imp' to instruct Urho2D to use the atlas instead of the individual files). You could remove every image files in the 'imp' folder and just keep 'imp_all.png' to test it out. However, keep your individual image files as they are still required if you want to later edit your scml project in Spriter. If more than one spritesheet is needed for a single scml file, add the suffix _0, _1 and so on to the spritesheets, like this: 'imp_0.xml'.
 
 A *.scml file is loaded using AnimationSet2D class (Resource) and rendered using AnimatedSprite2D class (Drawable component):
 
@@ -2686,7 +2686,7 @@ For a demonstration, check examples 33_Urho2DSpriterAnimation and 24_Urho2DSprit
 
 Tip for naming your files:
 - if an xml file has the same name as an image file in the same repository, it is assumed that it is a texture parameter file
-- if an xml file has the same name as a Spriter scml file in the same repository, it is assumed that it is a spritesheet file
+- if an xml file has the same name as a Spriter scml file in the same repository, it is assumed that it is a spritesheet file. Use suffixes _0, _1 and so on if you need multiple spritesheet files for the same Spriter scml file.
 So to prevent conflicts, scml and image files shouldn't have the exact same name.
 
 \section Urho2D_Particle Particle emitters

--- a/Source/Urho3D/AngelScript/Generated_Members.h
+++ b/Source/Urho3D/AngelScript/Generated_Members.h
@@ -14560,6 +14560,13 @@ template <class T> void RegisterMembers_XMLFile(asIScriptEngine* engine, const c
 
 #ifdef URHO3D_URHO2D
 
+// const Vector<SharedPtr<Sprite2D>>& AnimationSet2D::GetSprites() const
+template <class T> CScriptArray* AnimationSet2D_constspVectorlesSharedPtrlesSprite2Dgregreamp_GetSprites_void_template(T* _ptr)
+{
+    const Vector<SharedPtr<Sprite2D>>& result = _ptr->GetSprites();
+    return VectorToHandleArray(result, "Array<Sprite2D@>");
+}
+
 // class AnimationSet2D | File: ../Urho2D/AnimationSet2D.h
 template <class T> void RegisterMembers_AnimationSet2D(asIScriptEngine* engine, const char* className)
 {
@@ -14580,6 +14587,9 @@ template <class T> void RegisterMembers_AnimationSet2D(asIScriptEngine* engine, 
 
     // Sprite2D* AnimationSet2D::GetSpriterFileSprite(int folderId, int fileId) const
     engine->RegisterObjectMethod(className, "Sprite2D@+ GetSpriterFileSprite(int, int) const", AS_METHODPR(T, GetSpriterFileSprite, (int, int) const, Sprite2D*), AS_CALL_THISCALL);
+
+    // const Vector<SharedPtr<Sprite2D>>& AnimationSet2D::GetSprites() const
+    engine->RegisterObjectMethod(className, "Array<Sprite2D@>@ GetSprites() const", AS_FUNCTION_OBJFIRST(AnimationSet2D_constspVectorlesSharedPtrlesSprite2Dgregreamp_GetSprites_void_template<AnimationSet2D>), AS_CALL_CDECL_OBJFIRST);
 
     // bool AnimationSet2D::HasAnimation(const String& animationName) const
     engine->RegisterObjectMethod(className, "bool HasAnimation(const String&in) const", AS_METHODPR(T, HasAnimation, (const String&) const, bool), AS_CALL_THISCALL);

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
@@ -471,6 +471,8 @@ void AnimatedSprite2D::UpdateSourceBatchesSpriter()
         if (!sprite)
             return;
 
+        SetSprite(sprite);
+
         if (timelineKey->useDefaultPivot_)
             sprite->GetDrawRectangle(drawRect, flipX_, flipY_);
         else

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -207,7 +207,7 @@ bool AnimationSet2D::HasAnimation(const String& animationName) const
 
 Sprite2D* AnimationSet2D::GetSprite() const
 {
-    if(!sprites_.Empty())
+    if (!sprites_.Empty())
     {
         return sprites_[0];
     }
@@ -234,11 +234,11 @@ Sprite2D* AnimationSet2D::GetSpriteFromSpriteSheets (const String& name) const
 {
     Sprite2D* foundSprite = nullptr;
 
-    for(const SharedPtr<SpriteSheet2D>& spritesheet : spriteSheets_)
+    for (const SharedPtr<SpriteSheet2D>& spritesheet : spriteSheets_)
     {
         foundSprite = spritesheet->GetSprite(name);
 
-        if(foundSprite)
+        if (foundSprite)
         {
             break;
         }
@@ -335,7 +335,8 @@ bool AnimationSet2D::BeginLoadSpriter(Deserializer& source)
     String spriteSheetFilePath;
 
     spriteSheetFilePath = parentPath + GetFileName(GetName()) + ".xml";
-    if(cache->Exists(spriteSheetFilePath))
+
+    if (cache->Exists(spriteSheetFilePath))
     {
         spriteSheetFilePaths_.Push(spriteSheetFilePath);
     }
@@ -343,7 +344,8 @@ bool AnimationSet2D::BeginLoadSpriter(Deserializer& source)
     // add other spritesheets with suffix _0, _1 and so on, if they exist
     unsigned suffix = 0;
     spriteSheetFilePath = parentPath + GetFileName(GetName()) + "_" + String(suffix) + ".xml";
-    while(cache->Exists(spriteSheetFilePath))
+
+    while (cache->Exists(spriteSheetFilePath))
     {
         spriteSheetFilePaths_.Push(spriteSheetFilePath);
 
@@ -354,7 +356,8 @@ bool AnimationSet2D::BeginLoadSpriter(Deserializer& source)
     if (spriteSheetFilePaths_.Empty())
     {
         spriteSheetFilePath = parentPath + GetFileName(GetName()) + ".plist";
-        if(cache->Exists(spriteSheetFilePath))
+
+        if (cache->Exists(spriteSheetFilePath))
         {
             spriteSheetFilePaths_.Push(spriteSheetFilePath);
         }
@@ -362,7 +365,8 @@ bool AnimationSet2D::BeginLoadSpriter(Deserializer& source)
         // add other spritesheets with suffix _0, _1 and so on, if they exist
         suffix = 0;
         spriteSheetFilePath = parentPath + GetFileName(GetName()) + "_" + String(suffix) + ".plist";
-        while(cache->Exists(spriteSheetFilePath))
+
+        while (cache->Exists(spriteSheetFilePath))
         {
             spriteSheetFilePaths_.Push(spriteSheetFilePath);
 
@@ -421,7 +425,7 @@ bool AnimationSet2D::EndLoadSpriter()
         {
             SpriteSheet2D* sheet = cache->GetResource<SpriteSheet2D>(spriteSheetFilePath);
 
-            if(sheet)
+            if (sheet)
             {
                 spriteSheets_.Push(SharedPtr<SpriteSheet2D>(sheet));
             }
@@ -463,7 +467,7 @@ bool AnimationSet2D::EndLoadSpriter()
                 unsigned key = folder->id_ << 16u | file->id_;
                 spriterFileSprites_[key] = sprite;
 
-                if(!sprites_.Contains(sprite))
+                if (!sprites_.Contains(sprite))
                 {
                     sprites_.Push(sprite);
                 }
@@ -524,7 +528,7 @@ bool AnimationSet2D::EndLoadSpriter()
                 Image* image = info.image_;
                 if (!allocator.Allocate(image->GetWidth() + 1, image->GetHeight() + 1, info.x, info.y))
                 {
-                    if(image->GetHeight() >= 2048 || image->GetWidth() >= 2048)
+                    if (image->GetHeight() >= 2048 || image->GetWidth() >= 2048)
                     {
                         URHO3D_LOGERROR("AnimationSet2D: Could not allocate area");
                         return false;
@@ -542,7 +546,7 @@ bool AnimationSet2D::EndLoadSpriter()
 
             // create a sprite for each allocator used
             Vector<SharedArrayPtr<unsigned char>> textureDatas;
-            for(AreaAllocator& filledAlloc : filledAllocators )
+            for (AreaAllocator& filledAlloc : filledAllocators)
             {
                 SharedPtr<Texture2D> texture(new Texture2D(context_));
                 texture->SetMipsToSkip(QUALITY_LOW, 0);

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -103,12 +103,12 @@ namespace Urho3D
 {
 
 AnimationSet2D::AnimationSet2D(Context* context) :
-    Resource(context),
+    Resource(context)
 #ifdef URHO3D_SPINE
+    ,
     skeletonData_(0),
     atlas_(0),
 #endif
-    hasSpriteSheet_(false)
 {
 }
 
@@ -207,7 +207,17 @@ bool AnimationSet2D::HasAnimation(const String& animationName) const
 
 Sprite2D* AnimationSet2D::GetSprite() const
 {
-    return sprite_;
+    if(!sprites_.Empty())
+    {
+        return sprites_[0];
+    }
+
+    return nullptr;
+}
+
+const Vector<SharedPtr<Sprite2D>>& AnimationSet2D::GetSprites() const
+{
+    return sprites_;
 }
 
 Sprite2D* AnimationSet2D::GetSpriterFileSprite(int folderId, int fileId) const
@@ -218,6 +228,23 @@ Sprite2D* AnimationSet2D::GetSpriterFileSprite(int folderId, int fileId) const
         return i->second_;
 
     return nullptr;
+}
+
+Sprite2D* AnimationSet2D::GetSpriteFromSpriteSheets (const String& name) const
+{
+    Sprite2D* foundSprite = nullptr;
+
+    for(const SharedPtr<SpriteSheet2D>& spritesheet : spriteSheets_)
+    {
+        foundSprite = spritesheet->GetSprite(name);
+
+        if(foundSprite)
+        {
+            break;
+        }
+    }
+
+    return foundSprite;
 }
 
 #ifdef URHO3D_SPINE
@@ -305,18 +332,54 @@ bool AnimationSet2D::BeginLoadSpriter(Deserializer& source)
     String parentPath = GetParentPath(GetName());
     auto* cache = GetSubsystem<ResourceCache>();
 
-    spriteSheetFilePath_ = parentPath + GetFileName(GetName()) + ".xml";
-    hasSpriteSheet_ = cache->Exists(spriteSheetFilePath_);
-    if (!hasSpriteSheet_)
+    String spriteSheetFilePath;
+
+    spriteSheetFilePath = parentPath + GetFileName(GetName()) + ".xml";
+    if(cache->Exists(spriteSheetFilePath))
     {
-        spriteSheetFilePath_ = parentPath + GetFileName(GetName()) + ".plist";
-        hasSpriteSheet_ = cache->Exists(spriteSheetFilePath_);
+        spriteSheetFilePaths_.Push(spriteSheetFilePath);
+    }
+
+    // add other spritesheets with suffix _0, _1 and so on, if they exist
+    unsigned suffix = 0;
+    spriteSheetFilePath = parentPath + GetFileName(GetName()) + "_" + String(suffix) + ".xml";
+    while(cache->Exists(spriteSheetFilePath))
+    {
+        spriteSheetFilePaths_.Push(spriteSheetFilePath);
+
+        ++suffix;
+        spriteSheetFilePath = parentPath + GetFileName(GetName()) + "_" + String(suffix) + ".xml";
+    }
+
+    if (spriteSheetFilePaths_.Empty())
+    {
+        spriteSheetFilePath = parentPath + GetFileName(GetName()) + ".plist";
+        if(cache->Exists(spriteSheetFilePath))
+        {
+            spriteSheetFilePaths_.Push(spriteSheetFilePath);
+        }
+
+        // add other spritesheets with suffix _0, _1 and so on, if they exist
+        suffix = 0;
+        spriteSheetFilePath = parentPath + GetFileName(GetName()) + "_" + String(suffix) + ".plist";
+        while(cache->Exists(spriteSheetFilePath))
+        {
+            spriteSheetFilePaths_.Push(spriteSheetFilePath);
+
+            ++suffix;
+            spriteSheetFilePath = parentPath + GetFileName(GetName()) + "_" + String(suffix) + ".plist";
+        }
     }
 
     if (GetAsyncLoadState() == ASYNC_LOADING)
     {
-        if (hasSpriteSheet_)
-            cache->BackgroundLoadResource<SpriteSheet2D>(spriteSheetFilePath_, true, this);
+        if (!spriteSheetFilePaths_.Empty())
+        {
+            for (const String& spriteSheetFilePath : spriteSheetFilePaths_)
+            {
+                cache->BackgroundLoadResource<SpriteSheet2D>(spriteSheetFilePath, true, this);
+            }
+        }
         else
         {
             for (unsigned i = 0; i < spriterData_->folders_.Size(); ++i)
@@ -352,11 +415,21 @@ bool AnimationSet2D::EndLoadSpriter()
         return false;
 
     auto* cache = GetSubsystem<ResourceCache>();
-    if (hasSpriteSheet_)
+    if (!spriteSheetFilePaths_.Empty())
     {
-        spriteSheet_ = cache->GetResource<SpriteSheet2D>(spriteSheetFilePath_);
-        if (!spriteSheet_)
-            return false;
+        for (const String& spriteSheetFilePath : spriteSheetFilePaths_)
+        {
+            SpriteSheet2D* sheet = cache->GetResource<SpriteSheet2D>(spriteSheetFilePath);
+
+            if(sheet)
+            {
+                spriteSheets_.Push(SharedPtr<SpriteSheet2D>(sheet));
+            }
+            else
+            {
+                return false;
+            }
+        }
 
         for (unsigned i = 0; i < spriterData_->folders_.Size(); ++i)
         {
@@ -364,7 +437,7 @@ bool AnimationSet2D::EndLoadSpriter()
             for (unsigned j = 0; j < folder->files_.Size(); ++j)
             {
                 Spriter::File* file = folder->files_[j];
-                SharedPtr<Sprite2D> sprite(spriteSheet_->GetSprite(GetFileName(file->name_)));
+                SharedPtr<Sprite2D> sprite(GetSpriteFromSpriteSheets(GetFileName(file->name_)));
                 if (!sprite)
                 {
                     URHO3D_LOGERROR("Could not load sprite " + file->name_);
@@ -387,12 +460,13 @@ bool AnimationSet2D::EndLoadSpriter()
 
                 sprite->SetHotSpot(hotSpot);
 
-                if (!sprite_)
-                    sprite_ = sprite;
-
                 unsigned key = folder->id_ << 16u | file->id_;
                 spriterFileSprites_[key] = sprite;
 
+                if(!sprites_.Contains(sprite))
+                {
+                    sprites_.Push(sprite);
+                }
             }
         }
 
@@ -441,6 +515,8 @@ bool AnimationSet2D::EndLoadSpriter()
 
         if (spriteInfos.Size() > 1)
         {
+            Vector<AreaAllocator> filledAllocators;
+            PODVector<unsigned> allocatorIndexBySpriteInfo;
             AreaAllocator allocator(128, 128, 2048, 2048);
             for (unsigned i = 0; i < spriteInfos.Size(); ++i)
             {
@@ -448,36 +524,57 @@ bool AnimationSet2D::EndLoadSpriter()
                 Image* image = info.image_;
                 if (!allocator.Allocate(image->GetWidth() + 1, image->GetHeight() + 1, info.x, info.y))
                 {
-                    URHO3D_LOGERROR("Could not allocate area");
-                    return false;
+                    if(image->GetHeight() >= 2048 || image->GetWidth() >= 2048)
+                    {
+                        URHO3D_LOGERROR("AnimationSet2D: Could not allocate area");
+                        return false;
+                    }
+
+                    // allocator full! set up a new one
+                    filledAllocators.Push(allocator);
+                    allocator = AreaAllocator(128, 128, 2048, 2048);
+                    allocator.Allocate(image->GetWidth() + 1, image->GetHeight() + 1, info.x, info.y);
                 }
+
+                allocatorIndexBySpriteInfo.Push(filledAllocators.Size());
             }
+            filledAllocators.Push(allocator);
 
-            SharedPtr<Texture2D> texture(new Texture2D(context_));
-            texture->SetMipsToSkip(QUALITY_LOW, 0);
-            texture->SetNumLevels(1);
-            texture->SetSize(allocator.GetWidth(), allocator.GetHeight(), Graphics::GetRGBAFormat());
+            // create a sprite for each allocator used
+            Vector<SharedArrayPtr<unsigned char>> textureDatas;
+            for(AreaAllocator& filledAlloc : filledAllocators )
+            {
+                SharedPtr<Texture2D> texture(new Texture2D(context_));
+                texture->SetMipsToSkip(QUALITY_LOW, 0);
+                texture->SetNumLevels(1);
+                texture->SetSize(filledAlloc.GetWidth(), filledAlloc.GetHeight(), Graphics::GetRGBAFormat());
 
-            auto textureDataSize = (unsigned)allocator.GetWidth() * allocator.GetHeight() * 4;
-            SharedArrayPtr<unsigned char> textureData(new unsigned char[textureDataSize]);
-            memset(textureData.Get(), 0, textureDataSize);
+                auto textureDataSize = (unsigned)filledAlloc.GetWidth() * filledAlloc.GetHeight() * 4;
+                SharedArrayPtr<unsigned char> textureData(new unsigned char[textureDataSize]);
+                memset(textureData.Get(), 0, textureDataSize);
+                textureDatas.Push(textureData);
 
-            sprite_ = new Sprite2D(context_);
-            sprite_->SetTexture(texture);
+                auto sprite = SharedPtr<Sprite2D>(new Sprite2D(context_));
+                sprite->SetTexture(texture);
+                sprites_.Push(sprite);
+            }
 
             for (unsigned i = 0; i < spriteInfos.Size(); ++i)
             {
                 SpriteInfo& info = spriteInfos[i];
                 Image* image = info.image_;
+                unsigned allocatorIndex = allocatorIndexBySpriteInfo[i];
+                AreaAllocator& spriteAllocator = filledAllocators[allocatorIndex];
+                Sprite2D* allocatorSprite = sprites_[allocatorIndex];
 
                 for (int y = 0; y < image->GetHeight(); ++y)
                 {
-                    memcpy(textureData.Get() + ((info.y + y) * allocator.GetWidth() + info.x) * 4,
+                    memcpy(textureDatas[allocatorIndex].Get() + ((info.y + y) * spriteAllocator.GetWidth() + info.x) * 4,
                         image->GetData() + y * image->GetWidth() * 4, (size_t)image->GetWidth() * 4);
                 }
 
                 SharedPtr<Sprite2D> sprite(new Sprite2D(context_));
-                sprite->SetTexture(texture);
+                sprite->SetTexture(allocatorSprite->GetTexture());
                 sprite->SetRectangle(IntRect(info.x, info.y, info.x + image->GetWidth(), info.y + image->GetHeight()));
                 sprite->SetHotSpot(Vector2(info.file_->pivotX_, info.file_->pivotY_));
 
@@ -485,7 +582,11 @@ bool AnimationSet2D::EndLoadSpriter()
                 spriterFileSprites_[key] = sprite;
             }
 
-            texture->SetData(0, 0, 0, allocator.GetWidth(), allocator.GetHeight(), textureData.Get());
+            for (unsigned i = 0; i < filledAllocators.Size(); ++i)
+            {
+                AreaAllocator& filledAlloc = filledAllocators[i];
+                sprites_[i]->GetTexture()->SetData(0, 0, 0, filledAlloc.GetWidth(), filledAlloc.GetHeight(), textureDatas[i].Get());
+            }
         }
         else
         {
@@ -496,13 +597,14 @@ bool AnimationSet2D::EndLoadSpriter()
             SpriteInfo& info = spriteInfos[0];
             texture->SetData(info.image_, true);
 
-            sprite_ = new Sprite2D(context_);
-            sprite_->SetTexture(texture);
-            sprite_->SetRectangle(IntRect(info.x, info.y, info.x + info.image_->GetWidth(), info.y + info.image_->GetHeight()));
-            sprite_->SetHotSpot(Vector2(info.file_->pivotX_, info.file_->pivotY_));
+            auto singleSprite = SharedPtr<Sprite2D>(new Sprite2D(context_));
+            singleSprite->SetTexture(texture);
+            singleSprite->SetRectangle(IntRect(info.x, info.y, info.x + info.image_->GetWidth(), info.y + info.image_->GetHeight()));
+            singleSprite->SetHotSpot(Vector2(info.file_->pivotX_, info.file_->pivotY_));
 
             unsigned key = info.file_->folder_->id_ << 16u | info.file_->id_;
-            spriterFileSprites_[key] = sprite_;
+            spriterFileSprites_[key] = singleSprite;
+            sprites_.Push(singleSprite);
         }
 
         SubscribeToEvent(E_DEVICERESET, URHO3D_HANDLER(AnimationSet2D, HandleDeviceReset));
@@ -544,8 +646,9 @@ void AnimationSet2D::Dispose()
 
     spriterData_.Reset();
 
-    sprite_.Reset();
-    spriteSheet_.Reset();
+    sprites_.Clear();
+    spriteSheetFilePaths_.Clear();
+    spriteSheets_.Clear();
     spriterFileSprites_.Clear();
 }
 

--- a/Source/Urho3D/Urho2D/AnimationSet2D.h
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "../Container/ArrayPtr.h"
+#include "../Container/Vector.h"
 #include "../Resource/Resource.h"
 
 #ifdef URHO3D_SPINE
@@ -69,8 +70,10 @@ public:
     /// Check has animation.
     bool HasAnimation(const String& animationName) const;
 
-    /// Return sprite.
+    /// Return first sprite of spritesheet sprites, or nullptr.
     Sprite2D* GetSprite() const;
+    /// Return sprites.
+    const Vector<SharedPtr<Sprite2D>>& GetSprites() const;
 
 #ifdef URHO3D_SPINE
     /// Return spine skeleton data.
@@ -82,11 +85,13 @@ public:
     /// Return spriter file sprite.
     Sprite2D* GetSpriterFileSprite(int folderId, int fileId) const;
     /// True if a spritesheet xml file was found during the loading of this animationSet
-    bool HasSpriteSheet() const { return hasSpriteSheet_; }
+    bool HasSpriteSheet() const { return spriteSheets_.Size() > 0; }
 
 private:
     /// Return sprite by hash.
     Sprite2D* GetSpriterFileSprite(const StringHash& hash) const;
+    /// Return sprite by name.
+    Sprite2D* GetSpriteFromSpriteSheets(const String& name) const;
 #ifdef URHO3D_SPINE
     /// Begin load spine.
     bool BeginLoadSpine(Deserializer& source);
@@ -102,8 +107,8 @@ private:
     /// Dispose all data.
     void Dispose();
 
-    /// Spine sprite.
-    SharedPtr<Sprite2D> sprite_;
+    /// Spine sprites, or spriter container spritesheet sprites.
+    Vector<SharedPtr<Sprite2D>> sprites_;
 
 #ifdef URHO3D_SPINE
     /// Spine json data.
@@ -116,12 +121,10 @@ private:
 
     /// Spriter data.
     UniquePtr<Spriter::SpriterData> spriterData_;
-    /// Has sprite sheet.
-    bool hasSpriteSheet_;
-    /// Sprite sheet file path.
-    String spriteSheetFilePath_;
-    /// Sprite sheet.
-    SharedPtr<SpriteSheet2D> spriteSheet_;
+    /// Sprite sheet file paths.
+    Vector<String> spriteSheetFilePaths_;
+    /// Sprite sheets.
+    Vector<SharedPtr<SpriteSheet2D>> spriteSheets_;
     /// Spriter sprites.
     HashMap<unsigned, SharedPtr<Sprite2D> > spriterFileSprites_;
 };


### PR DESCRIPTION
Adds support for more than one source spritesheet texture when using a spriter .scml file. This makes it possible to circumvent the 2048x2048 texture size limit for a single spriter file.
If using "loose" sprites, instead of giving up when the 2048 size is reached, the engine will create another texture, and so on.
If using spritesheets, the engine looks for xml/plist sprite atlases with the same name as the .scml, just like before, but also looks for sprite atlases with the name plus a "_0", "_1" etc suffix. I've added this info to the dox file.