### PR TITLE
some fixes (casting parameters in memset) for LLVM Clang 22 

### DIFF
--- a/Source/ThirdParty/Assimp/code/AssetLib/IFC/IFCLoader.cpp
+++ b/Source/ThirdParty/Assimp/code/AssetLib/IFC/IFCLoader.cpp
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef ASSIMP_USE_HUNTER
 #include <minizip/unzip.h>
 #else
-#include <unzip.h>
+#include <minizip/unzip.h>
 #endif
 #endif
 
@@ -245,11 +245,11 @@ void IFCImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 
     // tell the reader for which types we need to simulate STEPs reverse indices
     static const char *const inverse_indices_to_track[] = {
-        "ifcrelcontainedinspatialstructure", 
-        "ifcrelaggregates", 
-        "ifcrelvoidselement", 
-        "ifcreldefinesbyproperties", 
-        "ifcpropertyset", 
+        "ifcrelcontainedinspatialstructure",
+        "ifcrelaggregates",
+        "ifcrelvoidselement",
+        "ifcreldefinesbyproperties",
+        "ifcpropertyset",
         "ifcstyleditem"
     };
 
@@ -260,7 +260,7 @@ void IFCImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
         ThrowException("missing IfcProject entity");
     }
 
-    
+
 
     ConversionData conv(*db, proj->To<Schema_2x3::IfcProject>(), pScene, settings);
     SetUnits(conv);

--- a/Source/ThirdParty/Assimp/code/AssetLib/IFC/IFCLoader.cpp
+++ b/Source/ThirdParty/Assimp/code/AssetLib/IFC/IFCLoader.cpp
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef ASSIMP_USE_HUNTER
 #include <minizip/unzip.h>
 #else
-#include <minizip/unzip.h>
+#include <unzip.h>
 #endif
 #endif
 

--- a/Source/ThirdParty/Assimp/code/Common/SceneCombiner.cpp
+++ b/Source/ThirdParty/Assimp/code/Common/SceneCombiner.cpp
@@ -994,7 +994,7 @@ inline void GetArrayCopy(Type *&dest, ai_uint num) {
     Type *old = dest;
 
     dest = new Type[num];
-    ::memcpy(dest, old, sizeof(Type) * num);
+    ::memcpy((void*)dest, old, sizeof(Type) * num);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/Source/ThirdParty/Assimp/code/Common/ZipArchiveIOSystem.cpp
+++ b/Source/ThirdParty/Assimp/code/Common/ZipArchiveIOSystem.cpp
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef ASSIMP_USE_HUNTER
 #    include <minizip/unzip.h>
 #else
-#    include <unzip.h>
+#    include <minizip/unzip.h>
 #endif
 
 namespace Assimp {

--- a/Source/ThirdParty/Assimp/code/Common/ZipArchiveIOSystem.cpp
+++ b/Source/ThirdParty/Assimp/code/Common/ZipArchiveIOSystem.cpp
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef ASSIMP_USE_HUNTER
 #    include <minizip/unzip.h>
 #else
-#    include <minizip/unzip.h>
+#    include <unzip.h>
 #endif
 
 namespace Assimp {

--- a/Source/ThirdParty/Assimp/contrib/Open3DGC/o3dgcCommon.h
+++ b/Source/ThirdParty/Assimp/contrib/Open3DGC/o3dgcCommon.h
@@ -117,7 +117,7 @@ namespace o3dgc
         O3DGC_IFS_FLOAT_ATTRIBUTE_TYPE_COLOR    = 3,
         O3DGC_IFS_FLOAT_ATTRIBUTE_TYPE_TEXCOORD = 4,
         O3DGC_IFS_FLOAT_ATTRIBUTE_TYPE_WEIGHT   = 5
-        
+
     };
     enum O3DGCIFSIntAttributeType
     {
@@ -127,31 +127,31 @@ namespace o3dgc
         O3DGC_IFS_INT_ATTRIBUTE_TYPE_INDEX_BUFFER_ID = 3
     };
 
-    template<class T> 
+    template<class T>
     inline const T absolute(const T& a)
     {
         return (a < (T)(0)) ? -a : a;
     }
-    template<class T> 
+    template<class T>
     inline const T min(const T& a, const T& b)
     {
         return (b < a) ? b : a;
     }
-    template<class T> 
+    template<class T>
     inline const T max(const T& a, const T& b)
     {
         return (b > a) ? b : a;
     }
-    template<class T> 
+    template<class T>
     inline void swap(T& a, T& b)
     {
         T tmp = a;
         a = b;
         b = tmp;
     }
-    inline double log2( double n )  
-    {  
-        return log(n) / log(2.0);  
+    inline double log2( double n )
+    {
+        return log(n) / log(2.0);
     }
 
     inline O3DGCEndianness SystemEndianness()
@@ -161,13 +161,13 @@ namespace o3dgc
     }
     class SC3DMCStats
     {
-    public: 
+    public:
                                     SC3DMCStats(void)
                                     {
-                                        memset(this, 0, sizeof(SC3DMCStats));
+                                        memset((void*)this, 0, sizeof(SC3DMCStats));
                                     };
                                     ~SC3DMCStats(void){};
-        
+
         double                      m_timeCoord;
         double                      m_timeNormal;
         double                      m_timeCoordIndex;
@@ -182,14 +182,14 @@ namespace o3dgc
         unsigned long               m_streamSizeIntAttribute  [O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES  ];
 
     };
-    typedef struct 
+    typedef struct
     {
         long          m_a;
         long          m_b;
         long          m_c;
     } SC3DMCTriplet;
 
-    typedef struct 
+    typedef struct
     {
         SC3DMCTriplet m_id;
         long          m_pred[O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES];
@@ -248,8 +248,8 @@ namespace o3dgc
         }
         return pos;
     }
-    template <class T> 
-    inline void SphereToCube(const T x, const T y, const T z, 
+    template <class T>
+    inline void SphereToCube(const T x, const T y, const T z,
                              T & a, T & b, char & index)
     {
         T ax = absolute(x);
@@ -346,8 +346,8 @@ namespace o3dgc
     {
         return (uiValue & 1)?-((long) ((uiValue+1) >> 1)):((long) (uiValue >> 1));
     }
-    inline void ComputeVectorMinMax(const Real * const tab, 
-                                    unsigned long size, 
+    inline void ComputeVectorMinMax(const Real * const tab,
+                                    unsigned long size,
                                     unsigned long dim,
                                     unsigned long stride,
                                     Real * minTab,
@@ -382,15 +382,15 @@ namespace o3dgc
             {
                 r     = (maxTab[d] - minTab[d]);
                 diag += r*r;
-            } 
+            }
             diag = static_cast<Real>(sqrt(diag));
             for(unsigned long d = 0; d < dim; ++d)
             {
                  maxTab[d] = minTab[d] + diag;
-            } 
+            }
         }
         else if (quantMode == O3DGC_SC3DMC_MAX_ALL_DIMS)
-        {            
+        {
             Real maxr = (maxTab[0] - minTab[0]);
             Real r;
             for(unsigned long d = 1; d < dim; ++d)
@@ -400,11 +400,11 @@ namespace o3dgc
                 {
                     maxr = r;
                 }
-            } 
+            }
             for(unsigned long d = 0; d < dim; ++d)
             {
                  maxTab[d] = minTab[d] + maxr;
-            } 
+            }
         }
     }
 }

--- a/Source/ThirdParty/Assimp/contrib/Open3DGC/o3dgcIndexedFaceSet.h
+++ b/Source/ThirdParty/Assimp/contrib/Open3DGC/o3dgcIndexedFaceSet.h
@@ -32,11 +32,11 @@ namespace o3dgc
     template<class T>
     class IndexedFaceSet
     {
-    public:    
+    public:
         //! Constructor.
                                          IndexedFaceSet(void)
                                          {
-                                             memset(this, 0, sizeof(IndexedFaceSet));
+                                             memset((void*)this, 0, sizeof(IndexedFaceSet));
                                              m_ccw              = true;
                                              m_solid            = true;
                                              m_convex           = true;
@@ -45,18 +45,18 @@ namespace o3dgc
                                          };
         //! Destructor.
                                          ~IndexedFaceSet(void) {};
-        
+
         unsigned long                    GetNCoordIndex() const { return m_nCoordIndex     ;}
         // only coordIndex is supported
         unsigned long                    GetNCoord()           const { return m_nCoord         ;}
         unsigned long                    GetNNormal()          const { return m_nNormal        ;}
-        unsigned long                    GetNFloatAttribute(unsigned long a)  const 
-                                         { 
+        unsigned long                    GetNFloatAttribute(unsigned long a)  const
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return m_nFloatAttribute[a];
                                          }
-        unsigned long                    GetNIntAttribute(unsigned long a)  const 
-                                         { 
+        unsigned long                    GetNIntAttribute(unsigned long a)  const
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              return m_nIntAttribute[a];
                                          }
@@ -72,43 +72,43 @@ namespace o3dgc
         Real                             GetNormalMax  (int j)  const { return m_normalMax[j]      ;}
 
         O3DGCIFSFloatAttributeType       GetFloatAttributeType(unsigned long a) const
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return m_typeFloatAttribute[a];
                                          }
         O3DGCIFSIntAttributeType         GetIntAttributeType(unsigned long a) const
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              return m_typeIntAttribute[a];
                                          }
         unsigned long                    GetFloatAttributeDim(unsigned long a) const
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return m_dimFloatAttribute[a];
                                          }
         unsigned long                    GetIntAttributeDim(unsigned long a) const
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              return m_dimIntAttribute[a];
                                          }
         const Real *                     GetFloatAttributeMin(unsigned long a) const
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return &(m_minFloatAttribute[a * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES]);
                                          }
         const Real *                     GetFloatAttributeMax(unsigned long a) const
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return &(m_maxFloatAttribute[a * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES]);
                                          }
         Real                             GetFloatAttributeMin(unsigned long a, unsigned long dim) const
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              assert(dim < O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES);
                                              return m_minFloatAttribute[a * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES + dim];
                                          }
         Real                             GetFloatAttributeMax(unsigned long a, unsigned long dim) const
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              assert(dim < O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES);
                                              return m_maxFloatAttribute[a * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES + dim];
@@ -139,20 +139,20 @@ namespace o3dgc
         void                             SetNFloatAttributeIndex(int, unsigned long) {}
         void                             SetNIntAttributeIndex (int, unsigned long) {}
         // per triangle attributes not supported
-        void                             SetNormalPerVertex(bool)   {} 
+        void                             SetNormalPerVertex(bool)   {}
         void                             SetColorPerVertex(bool)    {}
         void                             SetFloatAttributePerVertex(int, bool){}
         void                             SetIntAttributePerVertex  (int, bool){}
         void                             SetNCoordIndex     (unsigned long nCoordIndex)     { m_nCoordIndex = nCoordIndex;}
         void                             SetNCoord          (unsigned long nCoord)          { m_nCoord      = nCoord     ;}
         void                             SetNNormal         (unsigned long nNormal)         { m_nNormal     = nNormal    ;}
-        void                             SetNumFloatAttributes(unsigned long numFloatAttributes) 
-                                         { 
+        void                             SetNumFloatAttributes(unsigned long numFloatAttributes)
+                                         {
                                              assert(numFloatAttributes < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              m_numFloatAttributes = numFloatAttributes;
                                          }
         void                             SetNumIntAttributes  (unsigned long numIntAttributes)
-                                         { 
+                                         {
                                              assert(numIntAttributes < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              m_numIntAttributes = numIntAttributes;
                                          }
@@ -165,44 +165,44 @@ namespace o3dgc
         void                             SetCoordMax        (int j, Real max) { m_coordMax[j]    = max;}
         void                             SetNormalMin       (int j, Real min) { m_normalMin[j]   = min;}
         void                             SetNormalMax       (int j, Real max) { m_normalMax[j]   = max;}
-        void                             SetNFloatAttribute(unsigned long a, unsigned long nFloatAttribute) 
-                                         { 
+        void                             SetNFloatAttribute(unsigned long a, unsigned long nFloatAttribute)
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              m_nFloatAttribute[a] = nFloatAttribute;
                                          }
-        void                             SetNIntAttribute(unsigned long a, unsigned long nIntAttribute) 
-                                         { 
+        void                             SetNIntAttribute(unsigned long a, unsigned long nIntAttribute)
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              m_nIntAttribute[a] = nIntAttribute;
                                          }
         void                             SetFloatAttributeDim(unsigned long a, unsigned long d)
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              m_dimFloatAttribute[a] = d;
                                          }
         void                             SetIntAttributeDim(unsigned long a, unsigned long d)
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              m_dimIntAttribute[a] = d;
                                          }
         void                             SetFloatAttributeType(unsigned long a, O3DGCIFSFloatAttributeType t)
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              m_typeFloatAttribute[a] = t;
                                          }
         void                             SetIntAttributeType(unsigned long a, O3DGCIFSIntAttributeType t)
-                                         { 
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              m_typeIntAttribute[a] = t;
                                          }
-        void                             SetFloatAttributeMin(unsigned long a, unsigned long dim, Real min) 
-                                         { 
+        void                             SetFloatAttributeMin(unsigned long a, unsigned long dim, Real min)
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              assert(dim < O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES);
                                              m_minFloatAttribute[a * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES + dim] = min;
                                          }
-        void                             SetFloatAttributeMax(unsigned long a, unsigned long dim, Real max) 
-                                         { 
+        void                             SetFloatAttributeMax(unsigned long a, unsigned long dim, Real max)
+                                         {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              assert(dim < O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES);
                                              m_maxFloatAttribute[a * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES + dim] = max;
@@ -211,7 +211,7 @@ namespace o3dgc
         void                             SetCoordIndex     (T * const coordIndex)    { m_coordIndex = coordIndex;}
         void                             SetCoord          (Real * const coord     ) { m_coord      = coord    ;}
         void                             SetNormal         (Real * const normal    ) { m_normal     = normal   ;}
-        void                             SetFloatAttribute (unsigned long a, Real * const floatAttribute) 
+        void                             SetFloatAttribute (unsigned long a, Real * const floatAttribute)
                                          {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              m_floatAttribute[a] = floatAttribute;
@@ -250,7 +250,7 @@ namespace o3dgc
         Real                             m_maxFloatAttribute  [O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES];
         Real *                           m_floatAttribute     [O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES];
         long *                           m_intAttribute       [O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES];
-        // mesh info                     
+        // mesh info
         Real                             m_creaseAngle;
         bool                             m_ccw;
         bool                             m_solid;

--- a/Source/ThirdParty/Assimp/contrib/Open3DGC/o3dgcSC3DMCEncodeParams.h
+++ b/Source/ThirdParty/Assimp/contrib/Open3DGC/o3dgcSC3DMCEncodeParams.h
@@ -35,7 +35,7 @@ namespace o3dgc
         //! Constructor.
                                     SC3DMCEncodeParams(void)
                                     {
-                                        memset(this, 0, sizeof(SC3DMCEncodeParams));
+                                        memset((void*)this, 0, sizeof(SC3DMCEncodeParams));
                                         m_encodeMode        = O3DGC_SC3DMC_ENCODE_MODE_TFAN;
                                         m_streamTypeMode    = O3DGC_STREAM_TYPE_ASCII;
                                         m_coordQuantBits    = 14;
@@ -74,7 +74,7 @@ namespace o3dgc
                                        return m_floatAttributePredMode[a];
                                     }
         O3DGCSC3DMCPredictionMode   GetIntAttributePredMode(unsigned long a) const
-                                    { 
+                                    {
                                         assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                         return m_intAttributePredMode[a];
                                     }
@@ -92,32 +92,32 @@ namespace o3dgc
                                     }
         void                        SetStreamType(O3DGCStreamType streamTypeMode)  { m_streamTypeMode = streamTypeMode;}
         void                        SetEncodeMode(O3DGCSC3DMCEncodingMode encodeMode)  { m_encodeMode = encodeMode;}
-        void                        SetNumFloatAttributes(unsigned long numFloatAttributes) 
-                                    { 
+        void                        SetNumFloatAttributes(unsigned long numFloatAttributes)
+                                    {
                                         assert(numFloatAttributes < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                         m_numFloatAttributes = numFloatAttributes;
                                     }
         void                        SetNumIntAttributes  (unsigned long numIntAttributes)
-                                    { 
+                                    {
                                         assert(numIntAttributes < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                         m_numIntAttributes   = numIntAttributes;
                                     }
         void                        SetCoordQuantBits   (unsigned int coordQuantBits   ) { m_coordQuantBits    = coordQuantBits   ; }
         void                        SetNormalQuantBits  (unsigned int normalQuantBits  ) { m_normalQuantBits   = normalQuantBits  ; }
-        void                        SetFloatAttributeQuantBits(unsigned long a, unsigned long q) 
-                                    { 
+        void                        SetFloatAttributeQuantBits(unsigned long a, unsigned long q)
+                                    {
                                        assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                        m_floatAttributeQuantBits[a] = q;
                                     }
         void                        SetCoordPredMode   (O3DGCSC3DMCPredictionMode coordPredMode   ) { m_coordPredMode    = coordPredMode   ; }
         void                        SetNormalPredMode  (O3DGCSC3DMCPredictionMode normalPredMode  ) { m_normalPredMode   = normalPredMode  ; }
-        void                        SetFloatAttributePredMode(unsigned long a, O3DGCSC3DMCPredictionMode p) 
+        void                        SetFloatAttributePredMode(unsigned long a, O3DGCSC3DMCPredictionMode p)
                                     {
                                        assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                        m_floatAttributePredMode[a] = p;
-                                    }                       
-        void                        SetIntAttributePredMode(unsigned long a, O3DGCSC3DMCPredictionMode p) 
-                                    { 
+                                    }
+        void                        SetIntAttributePredMode(unsigned long a, O3DGCSC3DMCPredictionMode p)
+                                    {
                                         assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                         m_intAttributePredMode[a] = p;
                                     }
@@ -127,9 +127,9 @@ namespace o3dgc
         unsigned long               m_coordQuantBits;
         unsigned long               m_normalQuantBits;
         unsigned long               m_floatAttributeQuantBits[O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES];
-        
+
         O3DGCSC3DMCPredictionMode   m_coordPredMode;
-        O3DGCSC3DMCPredictionMode   m_normalPredMode; 
+        O3DGCSC3DMCPredictionMode   m_normalPredMode;
         O3DGCSC3DMCPredictionMode   m_floatAttributePredMode[O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES];
         O3DGCSC3DMCPredictionMode   m_intAttributePredMode  [O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES];
         O3DGCStreamType             m_streamTypeMode;

--- a/Source/ThirdParty/Assimp/contrib/Open3DGC/o3dgcTimer.h
+++ b/Source/ThirdParty/Assimp/contrib/Open3DGC/o3dgcTimer.h
@@ -47,7 +47,7 @@ namespace o3dgc
 #ifdef _WIN32
     class Timer
     {
-    public: 
+    public:
         Timer(void)
         {
             m_start.QuadPart = 0;
@@ -55,11 +55,11 @@ namespace o3dgc
             QueryPerformanceFrequency( &m_freq ) ;
         };
         ~Timer(void){};
-        void Tic() 
+        void Tic()
         {
             QueryPerformanceCounter(&m_start) ;
         }
-        void Toc() 
+        void Toc()
         {
             QueryPerformanceCounter(&m_stop);
         }
@@ -78,7 +78,7 @@ namespace o3dgc
 #elif __APPLE__
     class Timer
     {
-    public: 
+    public:
         Timer(void)
         {
             memset(this, 0, sizeof(Timer));
@@ -88,11 +88,11 @@ namespace o3dgc
         {
             mach_port_deallocate(mach_task_self(),  m_cclock);
         };
-        void Tic() 
+        void Tic()
         {
             clock_get_time( m_cclock, &m_start);
         }
-        void Toc() 
+        void Toc()
         {
             clock_get_time( m_cclock, &m_stop);
         }
@@ -108,17 +108,17 @@ namespace o3dgc
 #else
     class Timer
     {
-    public: 
+    public:
         Timer(void)
         {
-            memset(this, 0, sizeof(Timer));
+            memset((void*)this, 0, sizeof(Timer));
         };
         ~Timer(void){};
-        void Tic() 
+        void Tic()
         {
             clock_gettime(CLOCK_REALTIME, &m_start);
         }
-        void Toc() 
+        void Toc()
         {
             clock_gettime(CLOCK_REALTIME, &m_stop);
         }


### PR DESCRIPTION
casting memset first parameter with (void*) to stop LLVM Clang compiler from complaining 