### PR TITLE
Fix Spriter AnimatedSprite2D crash during parallel visibility checks

### DIFF
--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
@@ -23,6 +23,7 @@
 #include "../Precompiled.h"
 
 #include "../Core/Context.h"
+#include "../Graphics/Material.h"
 #include "../IO/Log.h"
 #include "../Resource/ResourceCache.h"
 #include "../Graphics/GraphicsEvents.h"
@@ -30,6 +31,7 @@
 #include "../Scene/SceneEvents.h"
 #include "../Urho2D/AnimatedSprite2D.h"
 #include "../Urho2D/AnimationSet2D.h"
+#include "../Urho2D/Renderer2D.h"
 #include "../Urho2D/Sprite2D.h"
 #include "../Urho2D/SpriterInstance2D.h"
 
@@ -429,6 +431,9 @@ void AnimatedSprite2D::UpdateSpriterAnimation(float timeStep)
 
 void AnimatedSprite2D::UpdateSourceBatchesSpriter()
 {
+    if (!animationSet_ || !spriterInstance_ || !spriterInstance_->GetAnimation())
+        return;
+
     const Matrix3x4& nodeWorldTransform = GetNode()->GetWorldTransform();
 
     Vector<Vertex2D>& vertices = sourceBatches_[0].vertices_;
@@ -471,7 +476,10 @@ void AnimatedSprite2D::UpdateSourceBatchesSpriter()
         if (!sprite)
             return;
 
-        SetSprite(sprite);
+        // Per-frame material without SetSprite(): visibility checks may rebuild batches
+        // on a worker thread; SetSprite mutates sprite_ (SharedPtr) and is not thread-safe.
+        if (renderer_ && sprite->GetTexture())
+            sourceBatches_[0].material_ = renderer_->GetMaterial(sprite->GetTexture(), blendMode_);
 
         if (timelineKey->useDefaultPivot_)
             sprite->GetDrawRectangle(drawRect, flipX_, flipY_);


### PR DESCRIPTION
I encountered a problem while playing Spriter animations. Stack trace pointed at SetSprite inside UpdateSourceBatchesSpriter, called from a worker thread via Renderer2D visibility checks (CheckDrawableVisibilityWork → GetWorldBoundingBox → GetSourceBatches).

At the same time, the main thread updates the same AnimatedSprite2D via UpdateSpriterAnimation and SetAnimation. The old code called SetSprite(sprite) during batch rebuild, which mutates sprite_ (SharedPtr) and is not thread-safe.

To fix I replaced SetSprite(sprite) with per-frame material assignment.
This binds the correct texture without touching sprite_ or other SetSprite side effects. Add early-out guards for missing animation state.