### PR TITLE
Editor: "keep showing camera after deselect" option

### DIFF
--- a/bin/Data/Scripts/Editor/EditorSettings.as
+++ b/bin/Data/Scripts/Editor/EditorSettings.as
@@ -37,6 +37,8 @@ void UpdateEditorSettingsDialog()
     CheckBox@ limitRotationToggle = settingsDialog.GetChild("LimitRotationToggle", true);
     limitRotationToggle.checked = limitRotation;
 
+    CheckBox@ keepShowingCameraToggle = settingsDialog.GetChild("KeepShowingCameraPreviewToggle", true);
+    keepShowingCameraToggle.checked = keepShowingCameraPreview;
 
     DropDownList@ mouseOrbitEdit = settingsDialog.GetChild("MouseOrbitEdit", true);
     mouseOrbitEdit.selection = mouseOrbitMode;
@@ -140,6 +142,7 @@ void UpdateEditorSettingsDialog()
         SubscribeToEvent(speedEdit, "TextChanged", "EditCameraSpeed");
         SubscribeToEvent(speedEdit, "TextFinished", "EditCameraSpeed");
         SubscribeToEvent(limitRotationToggle, "Toggled", "EditLimitRotation");
+        SubscribeToEvent(keepShowingCameraToggle, "Toggled", "EditKeepShowingCamera");
         SubscribeToEvent(middleMousePanToggle, "Toggled", "EditMiddleMousePan");
         SubscribeToEvent(rotateAroundSelectToggle, "Toggled", "EditRotateAroundSelect");
         SubscribeToEvent(mouseOrbitEdit, "ItemSelected", "EditMouseOrbitMode");
@@ -248,6 +251,12 @@ void EditLimitRotation(StringHash eventType, VariantMap& eventData)
 {
     CheckBox@ edit = eventData["Element"].GetPtr();
     limitRotation = edit.checked;
+}
+
+void EditKeepShowingCamera(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox@ edit = eventData["Element"].GetPtr();
+    keepShowingCameraPreview = edit.checked;
 }
 
 void EditMouseOrbitMode(StringHash eventType, VariantMap& eventData)

--- a/bin/Data/Scripts/Editor/EditorView.as
+++ b/bin/Data/Scripts/Editor/EditorView.as
@@ -1,6 +1,7 @@
 // Urho3D editor view & camera functions
 
 WeakHandle previewCamera;
+WeakHandle lastSelectedCamera = null;
 
 Node@ cameraLookAtNode;
 Node@ cameraNode;
@@ -41,6 +42,7 @@ IntVector2 oldHierarchyWindowPosition; // used for restore hierarchy position wh
 int oldHierarchyWindowHeight;
 IntVector2 oldInspectorWindowPosition; // used for restore inspector position when switch between viewport modes
 int oldInspectorWindowHeight;
+bool keepShowingCameraPreview = false;
 
 const uint VIEWPORT_BORDER_H     = 0x00000001;
 const uint VIEWPORT_BORDER_H1    = 0x00000002;
@@ -1057,6 +1059,7 @@ void UpdateCameraPreview()
         {
             // Take the first encountered camera
             previewCamera = selectedComponents[i];
+            lastSelectedCamera = previewCamera.Get();
             break;
         }
     }
@@ -1066,9 +1069,17 @@ void UpdateCameraPreview()
         for (uint i = 0; i < selectedNodes.length; ++i)
         {
             previewCamera = selectedNodes[i].GetComponent("Camera");
-            if (previewCamera.Get() !is null)
+            if (previewCamera.Get() !is null) 
+            {
+                lastSelectedCamera = previewCamera.Get();
                 break;
+            }
         }
+    }
+
+    if(keepShowingCameraPreview)
+    {
+        previewCamera = lastSelectedCamera.Get();
     }
 
     // Remove extra viewport if it exists and no camera is selected

--- a/bin/Data/Translation/EditorStrings.json
+++ b/bin/Data/Translation/EditorStrings.json
@@ -1426,5 +1426,10 @@
 		"en":"Show Grid",
 		"ru":"Показывать сетку",
 		"it":"Visualizza griglia"
+	},
+	"Keep camera preview after deselect":{
+		"en":"Keep camera preview after deselect",
+		"ru":"Сохранять предварительный просмотр камеры после снятия выделения",
+		"it":"Mantieni l'anteprima della camera dopo aver deselezionato"
 	}
 }

--- a/bin/Data/UI/EditorSettingsDialog.xml
+++ b/bin/Data/UI/EditorSettingsDialog.xml
@@ -81,6 +81,15 @@
                 <element style="ListRow">
                     <attribute name="Layout Spacing" value="8" />
                     <element type="CheckBox">
+                        <attribute name="Name" value="KeepShowingCameraPreviewToggle" />
+                    </element>
+                    <element type="Text">
+                        <attribute name="Text" value="Keep camera preview after deselect" />
+                    </element>
+                </element>
+                <element style="ListRow">
+                    <attribute name="Layout Spacing" value="8" />
+                    <element type="CheckBox">
                         <attribute name="Name" value="MiddleMousePanToggle" />
                     </element>
                     <element type="Text">


### PR DESCRIPTION
Adds an option in the editor settings window to prevent the last selected camera's preview from disappearing once we deselect it in the scene hierarchy. This could make positioning things relative to the camera easier.