### PR TITLE
Editor res. browser: add 2d particle and particleEmitter previews

### DIFF
--- a/bin/Data/Scripts/Editor/EditorResourceBrowser.as
+++ b/bin/Data/Scripts/Editor/EditorResourceBrowser.as
@@ -354,6 +354,7 @@ void InitializeBrowserFileListRow(Text@ fileText, BrowserFile@ file)
     if (file.resourceType == RESOURCE_TYPE_MATERIAL ||
             file.resourceType == RESOURCE_TYPE_MODEL ||
             file.resourceType == RESOURCE_TYPE_PARTICLEEFFECT ||
+            file.resourceType == RESOURCE_TYPE_PARTICLEEMITTER ||
             file.resourceType == RESOURCE_TYPE_PREFAB
         )
     {
@@ -451,7 +452,7 @@ void HandleBrowserFileClick(StringHash eventType, VariantMap& eventData)
     {
         actions.Push(CreateBrowserFileActionMenu("Execute Script", "HandleBrowserRunScript", file));
     }
-    else if (file.resourceType == RESOURCE_TYPE_PARTICLEEFFECT)
+    else if (file.resourceType == RESOURCE_TYPE_PARTICLEEFFECT || file.resourceType == RESOURCE_TYPE_PARTICLEEMITTER)
     {
         actions.Push(CreateBrowserFileActionMenu("Edit", "HandleBrowserEditResource", file));
     }
@@ -897,7 +898,7 @@ void HandleBrowserEditResource(StringHash eventType, VariantMap& eventData)
             EditMaterial(material);
     }
 
-    if (file.resourceType == RESOURCE_TYPE_PARTICLEEFFECT)
+    if (file.resourceType == RESOURCE_TYPE_PARTICLEEFFECT || file.resourceType == RESOURCE_TYPE_PARTICLEEMITTER)
     {
         ParticleEffect@ particleEffect = cache.GetResource("ParticleEffect", file.resourceKey);
         if (particleEffect !is null)
@@ -1636,7 +1637,7 @@ void CreateResourcePreview(String path, Node@ previewNode)
             previewNode.RemoveAllChildren();
             previewNode.RemoveAllComponents();
         }
-        else if (resourceType == RESOURCE_TYPE_PARTICLEEFFECT)
+        else if (resourceType == RESOURCE_TYPE_PARTICLEEFFECT || resourceType == RESOURCE_TYPE_PARTICLEEMITTER)
         {
             ParticleEffect@ particleEffect = ParticleEffect();
             if (particleEffect.Load(file))

--- a/bin/Data/Scripts/Editor/EditorResourceBrowser.as
+++ b/bin/Data/Scripts/Editor/EditorResourceBrowser.as
@@ -1649,6 +1649,17 @@ void CreateResourcePreview(String path, Node@ previewNode)
                 return;
             }
         }
+        else if (resourceType == RESOURCE_TYPE_2D_PARTICLE_EFFECT)
+        {
+            ParticleEffect2D@ particleEffect2d = ParticleEffect2D();
+            if (particleEffect2d.Load(file))
+            {
+                ParticleEmitter2D@ particleEmitter2d = previewNode.CreateComponent("ParticleEmitter2D");
+                particleEmitter2d.effect = particleEffect2d;
+                resourceBrowserPreview.autoUpdate = true;
+                return;
+            }
+        }
     }
 
     StaticModel@ staticModel = previewNode.CreateComponent("StaticModel");


### PR DESCRIPTION
2D particles and particleEmitter xml files (which seem to be the same as particleEffect ones) wouldn't show how they look in the Resource Browser... now they do!
This also adds the "edit" context option for the particleEmitters, opening the particle editor. When saved via the particle editor, they become particle effects. Is there a reason for someone to want to keep them as particleEmitter instead of particleEffect?