### PR TITLE
Editor: add particle 2d editor + extra methods for 2d particle effect and emitter

### DIFF
--- a/Source/Urho3D/AngelScript/Generated_Members.h
+++ b/Source/Urho3D/AngelScript/Generated_Members.h
@@ -14725,6 +14725,12 @@ template <class T> void RegisterMembers_ParticleEffect2D(asIScriptEngine* engine
     // float ParticleEffect2D::GetTangentialAccelVariance() const
     engine->RegisterObjectMethod(className, "float GetTangentialAccelVariance() const", AS_METHODPR(T, GetTangentialAccelVariance, () const, float), AS_CALL_THISCALL);
 
+    // bool ParticleEffect2D::Load(const XMLElement& source)
+    engine->RegisterObjectMethod(className, "bool Load(const XMLElement&in)", AS_METHODPR(T, Load, (const XMLElement&), bool), AS_CALL_THISCALL);
+
+    // bool ParticleEffect2D::Save(XMLElement& dest) const
+    engine->RegisterObjectMethod(className, "bool Save(XMLElement&) const", AS_METHODPR(T, Save, (XMLElement&) const, bool), AS_CALL_THISCALL);
+
     // void ParticleEffect2D::SetAngle(float angle)
     engine->RegisterObjectMethod(className, "void SetAngle(float)", AS_METHODPR(T, SetAngle, (float), void), AS_CALL_THISCALL);
 
@@ -25122,6 +25128,15 @@ template <class T> void RegisterMembers_ParticleEmitter2D(asIScriptEngine* engin
     // bool ParticleEmitter2D::IsEmitting() const
     engine->RegisterObjectMethod(className, "bool IsEmitting() const", AS_METHODPR(T, IsEmitting, () const, bool), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "bool get_emitting() const", AS_METHODPR(T, IsEmitting, () const, bool), AS_CALL_THISCALL);
+
+    // void ParticleEmitter2D::RemoveAllParticles()
+    engine->RegisterObjectMethod(className, "void RemoveAllParticles()", AS_METHODPR(T, RemoveAllParticles, (), void), AS_CALL_THISCALL);
+
+    // void ParticleEmitter2D::Reset()
+    engine->RegisterObjectMethod(className, "void Reset()", AS_METHODPR(T, Reset, (), void), AS_CALL_THISCALL);
+
+    // void ParticleEmitter2D::ResetEmissionTimer()
+    engine->RegisterObjectMethod(className, "void ResetEmissionTimer()", AS_METHODPR(T, ResetEmissionTimer, (), void), AS_CALL_THISCALL);
 
     // void ParticleEmitter2D::SetBlendMode(BlendMode blendMode)
     engine->RegisterObjectMethod(className, "void SetBlendMode(BlendMode)", AS_METHODPR(T, SetBlendMode, (BlendMode), void), AS_CALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/Urho2D/ParticleEmitter2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Urho2D/ParticleEmitter2D.pkg
@@ -7,6 +7,9 @@ public:
     void SetSprite(Sprite2D* sprite);
     void SetBlendMode(BlendMode blendMode);
     void SetEmitting(bool emitting);
+    void RemoveAllParticles();
+    void Reset();
+    void ResetEmissionTimer();
 
     ParticleEffect2D* GetEffect() const;
     Sprite2D* GetSprite() const;

--- a/Source/Urho3D/Urho2D/ParticleEffect2D.cpp
+++ b/Source/Urho3D/Urho2D/ParticleEffect2D.cpp
@@ -88,7 +88,7 @@ ParticleEffect2D::ParticleEffect2D(Context* context) :
     startParticleSizeVariance_(40.0f),
     finishParticleSize_(5.0f),
     finishParticleSizeVariance_(5.0f),
-    duration_(-1.0f),
+    duration_(M_INFINITY),
     emitterType_(EMITTER_TYPE_GRAVITY),
     maxRadius_(100.0f),
     maxRadiusVariance_(0.0f),
@@ -126,86 +126,11 @@ bool ParticleEffect2D::BeginLoad(Deserializer& source)
     if (!rootElem)
         return false;
 
-    String texture = rootElem.GetChild("texture").GetAttribute("name");
-    loadSpriteName_ = GetParentPath(GetName()) + texture;
-    // If async loading, request the sprite beforehand
-    if (GetAsyncLoadState() == ASYNC_LOADING)
-        GetSubsystem<ResourceCache>()->BackgroundLoadResource<Sprite2D>(loadSpriteName_, true, this);
-
-    sourcePositionVariance_ = ReadVector2(rootElem, "sourcePositionVariance");
-
-    speed_ = ReadFloat(rootElem, "speed");
-    speedVariance_ = ReadFloat(rootElem, "speedVariance");
-
-    particleLifeSpan_ = Max(0.01f, ReadFloat(rootElem, "particleLifeSpan"));
-    particleLifespanVariance_ = ReadFloat(rootElem, "particleLifespanVariance");
-
-    angle_ = ReadFloat(rootElem, "angle");
-    angleVariance_ = ReadFloat(rootElem, "angleVariance");
-
-    gravity_ = ReadVector2(rootElem, "gravity");
-
-    radialAcceleration_ = ReadFloat(rootElem, "radialAcceleration");
-    tangentialAcceleration_ = ReadFloat(rootElem, "tangentialAcceleration");
-
-    radialAccelVariance_ = ReadFloat(rootElem, "radialAccelVariance");
-    tangentialAccelVariance_ = ReadFloat(rootElem, "tangentialAccelVariance");
-
-    startColor_ = ReadColor(rootElem, "startColor");
-    startColorVariance_ = ReadColor(rootElem, "startColorVariance");
-
-    finishColor_ = ReadColor(rootElem, "finishColor");
-    finishColorVariance_ = ReadColor(rootElem, "finishColorVariance");
-
-    maxParticles_ = ReadInt(rootElem, "maxParticles");
-
-    startParticleSize_ = ReadFloat(rootElem, "startParticleSize");
-    startParticleSizeVariance_ = ReadFloat(rootElem, "startParticleSizeVariance");
-
-    finishParticleSize_ = ReadFloat(rootElem, "finishParticleSize");
-    // Typo in pex file
-    finishParticleSizeVariance_ = ReadFloat(rootElem, "FinishParticleSizeVariance");
-
-    duration_ = M_INFINITY;
-    if (rootElem.HasChild("duration"))
-    {
-        float duration = ReadFloat(rootElem, "duration");
-        if (duration > 0.0f)
-            duration_ = duration;
-    }
-
-
-    emitterType_ = (EmitterType2D)ReadInt(rootElem, "emitterType");
-
-    maxRadius_ = ReadFloat(rootElem, "maxRadius");
-    maxRadiusVariance_ = ReadFloat(rootElem, "maxRadiusVariance");
-    minRadius_ = ReadFloat(rootElem, "minRadius");
-    minRadiusVariance_ = ReadFloat(rootElem, "minRadiusVariance");
-
-    rotatePerSecond_ = ReadFloat(rootElem, "rotatePerSecond");
-    rotatePerSecondVariance_ = ReadFloat(rootElem, "rotatePerSecondVariance");
-
-    int blendFuncSource = ReadInt(rootElem, "blendFuncSource");
-    int blendFuncDestination = ReadInt(rootElem, "blendFuncDestination");
-    blendMode_ = BLEND_ALPHA;
-    for (int i = 0; i < MAX_BLENDMODES; ++i)
-    {
-        if (blendFuncSource == srcBlendFuncs[i] && blendFuncDestination == destBlendFuncs[i])
-        {
-            blendMode_ = (BlendMode)i;
-            break;
-        }
-    }
-
-    rotationStart_ = ReadFloat(rootElem, "rotationStart");
-    rotationStartVariance_ = ReadFloat(rootElem, "rotationStartVariance");
-
-    rotationEnd_ = ReadFloat(rootElem, "rotationEnd");
-    rotationEndVariance_ = ReadFloat(rootElem, "rotationEndVariance");
-
     // Note: not accurate
-    SetMemoryUse(source.GetSize());
-    return true;
+    bool success = Load(rootElem);
+    if (success)
+        SetMemoryUse(source.GetSize());
+    return success;
 }
 
 bool ParticleEffect2D::EndLoad()
@@ -232,68 +157,273 @@ bool ParticleEffect2D::Save(Serializer& dest) const
     XMLFile xmlFile(context_);
     XMLElement rootElem = xmlFile.CreateRoot("particleEmitterConfig");
 
+    Save(rootElem);
+
+    return xmlFile.Save(dest);
+}
+
+bool ParticleEffect2D::Save(XMLElement& dest) const
+{
+    if (!sprite_)
+        return false;
+
+    if (dest.IsNull())
+    {
+        URHO3D_LOGERROR("Can not save particle effect to null XML element");
+        return false;
+    }
+
     String fileName = GetFileNameAndExtension(sprite_->GetName());
-    rootElem.CreateChild("texture").SetAttribute("name", fileName);
+    dest.CreateChild("texture").SetAttribute("name", fileName);
 
-    WriteVector2(rootElem, "sourcePosition", Vector2::ZERO);
-    WriteVector2(rootElem, "sourcePositionVariance", sourcePositionVariance_);
+    WriteVector2(dest, "sourcePosition", Vector2::ZERO);
+    WriteVector2(dest, "sourcePositionVariance", sourcePositionVariance_);
 
-    WriteFloat(rootElem, "speed", speed_);
-    WriteFloat(rootElem, "speedVariance", speedVariance_);
+    WriteFloat(dest, "speed", speed_);
+    WriteFloat(dest, "speedVariance", speedVariance_);
 
-    WriteFloat(rootElem, "particleLifeSpan", particleLifeSpan_);
-    WriteFloat(rootElem, "particleLifespanVariance", particleLifespanVariance_);
+    WriteFloat(dest, "particleLifeSpan", particleLifeSpan_);
+    WriteFloat(dest, "particleLifespanVariance", particleLifespanVariance_);
 
-    WriteFloat(rootElem, "angle", angle_);
-    WriteFloat(rootElem, "angleVariance", angleVariance_);
+    WriteFloat(dest, "angle", angle_);
+    WriteFloat(dest, "angleVariance", angleVariance_);
 
-    WriteVector2(rootElem, "gravity", gravity_);
+    WriteVector2(dest, "gravity", gravity_);
 
-    WriteFloat(rootElem, "radialAcceleration", radialAcceleration_);
-    WriteFloat(rootElem, "tangentialAcceleration", tangentialAcceleration_);
+    WriteFloat(dest, "radialAcceleration", radialAcceleration_);
+    WriteFloat(dest, "tangentialAcceleration", tangentialAcceleration_);
 
-    WriteFloat(rootElem, "radialAccelVariance", radialAccelVariance_);
-    WriteFloat(rootElem, "tangentialAccelVariance", tangentialAccelVariance_);
+    WriteFloat(dest, "radialAccelVariance", radialAccelVariance_);
+    WriteFloat(dest, "tangentialAccelVariance", tangentialAccelVariance_);
 
-    WriteColor(rootElem, "startColor", startColor_);
-    WriteColor(rootElem, "startColorVariance", startColorVariance_);
+    WriteColor(dest, "startColor", startColor_);
+    WriteColor(dest, "startColorVariance", startColorVariance_);
 
-    WriteColor(rootElem, "finishColor", finishColor_);
-    WriteColor(rootElem, "finishColorVariance", finishColorVariance_);
+    WriteColor(dest, "finishColor", finishColor_);
+    WriteColor(dest, "finishColorVariance", finishColorVariance_);
 
-    WriteInt(rootElem, "maxParticles", maxParticles_);
+    WriteInt(dest, "maxParticles", maxParticles_);
 
-    WriteFloat(rootElem, "startParticleSize", startParticleSize_);
-    WriteFloat(rootElem, "startParticleSizeVariance", startParticleSizeVariance_);
+    WriteFloat(dest, "startParticleSize", startParticleSize_);
+    WriteFloat(dest, "startParticleSizeVariance", startParticleSizeVariance_);
 
-    WriteFloat(rootElem, "finishParticleSize", finishParticleSize_);
+    WriteFloat(dest, "finishParticleSize", finishParticleSize_);
     // Typo in pex file
-    WriteFloat(rootElem, "FinishParticleSizeVariance", finishParticleSizeVariance_);
+    WriteFloat(dest, "FinishParticleSizeVariance", finishParticleSizeVariance_);
 
     float duration = duration_;
     if (duration == M_INFINITY)
         duration = -1.0f;
-    WriteFloat(rootElem, "duration", duration);
-    WriteInt(rootElem, "emitterType", (int)emitterType_);
+    WriteFloat(dest, "duration", duration);
+    WriteInt(dest, "emitterType", (int)emitterType_);
 
-    WriteFloat(rootElem, "maxRadius", maxRadius_);
-    WriteFloat(rootElem, "maxRadiusVariance", maxRadiusVariance_);
-    WriteFloat(rootElem, "minRadius", minRadius_);
-    WriteFloat(rootElem, "minRadiusVariance", minRadiusVariance_);
+    WriteFloat(dest, "maxRadius", maxRadius_);
+    WriteFloat(dest, "maxRadiusVariance", maxRadiusVariance_);
+    WriteFloat(dest, "minRadius", minRadius_);
+    WriteFloat(dest, "minRadiusVariance", minRadiusVariance_);
 
-    WriteFloat(rootElem, "rotatePerSecond", rotatePerSecond_);
-    WriteFloat(rootElem, "rotatePerSecondVariance", rotatePerSecondVariance_);
+    WriteFloat(dest, "rotatePerSecond", rotatePerSecond_);
+    WriteFloat(dest, "rotatePerSecondVariance", rotatePerSecondVariance_);
 
-    WriteInt(rootElem, "blendFuncSource", srcBlendFuncs[blendMode_]);
-    WriteInt(rootElem, "blendFuncDestination", destBlendFuncs[blendMode_]);
+    WriteInt(dest, "blendFuncSource", srcBlendFuncs[blendMode_]);
+    WriteInt(dest, "blendFuncDestination", destBlendFuncs[blendMode_]);
 
-    WriteFloat(rootElem, "rotationStart", rotationStart_);
-    WriteFloat(rootElem, "rotationStartVariance", rotationStartVariance_);
+    WriteFloat(dest, "rotationStart", rotationStart_);
+    WriteFloat(dest, "rotationStartVariance", rotationStartVariance_);
 
-    WriteFloat(rootElem, "rotationEnd", rotationEnd_);
-    WriteFloat(rootElem, "rotationEndVariance", rotationEndVariance_);
+    WriteFloat(dest, "rotationEnd", rotationEnd_);
+    WriteFloat(dest, "rotationEndVariance", rotationEndVariance_);
 
-    return xmlFile.Save(dest);
+    return true;
+}
+
+bool ParticleEffect2D::Load(const XMLElement& source)
+{
+    // Reset to defaults first so that missing parameters in case of a live reload behave as expected
+    sourcePositionVariance_ = Vector2(7.0f, 7.0f);
+    speed_ = 260.0f;
+    speedVariance_ = 10.0f;
+    particleLifeSpan_ = 1.000f;
+    particleLifespanVariance_ = 0.700f;
+    angle_ = 0.0f;
+    angleVariance_ = 360.0f;
+    gravity_ = Vector2(0.0f, 0.0f);
+    radialAcceleration_ = -380.0f;
+    tangentialAcceleration_ = -140.0f;
+    radialAccelVariance_ = 0.0f;
+    tangentialAccelVariance_ = 0.0f;
+    startColor_ = Color(1.0f, 0.0f, 0.0f, 1.0f);
+    startColorVariance_ = Color(0.0f, 0.0f, 0.0f, 0.0f);
+    finishColor_ = Color(1.0f, 1.0f, 0.0f, 1.0f);
+    finishColorVariance_ = Color(0.0f, 0.0f, 0.0f, 0.0f);
+    maxParticles_ = 600;
+    startParticleSize_ = 60.0f;
+    startParticleSizeVariance_ = 40.0f;
+    finishParticleSize_ = 5.0f;
+    finishParticleSizeVariance_ = 5.0f;
+    duration_ = M_INFINITY;
+    emitterType_ = EMITTER_TYPE_GRAVITY;
+    maxRadius_ = 100.0f;
+    maxRadiusVariance_ = 0.0f;
+    minRadius_ = 0.0f;
+    minRadiusVariance_ = 0.0f;
+    rotatePerSecond_ = 0.0f;
+    rotatePerSecondVariance_ = 0.0f;
+    blendMode_ = BLEND_ALPHA;
+    rotationStart_ = 0.0f;
+    rotationStartVariance_ = 0.0f;
+    rotationEnd_ = 0.0f;
+    rotationEndVariance_ = 0.0f;
+
+    if (source.IsNull())
+    {
+        URHO3D_LOGERROR("Can not load particle effect 2D from null XML element");
+        return false;
+    }
+
+
+    if(source.HasChild("texture"))
+    {
+        String texture = source.GetChild("texture").GetAttribute("name");
+        loadSpriteName_ = GetParentPath(GetName()) + texture;
+        // If async loading, request the sprite beforehand
+        if (GetAsyncLoadState() == ASYNC_LOADING)
+            GetSubsystem<ResourceCache>()->BackgroundLoadResource<Sprite2D>(loadSpriteName_, true, this);
+    }
+
+
+    if(source.HasChild("sourcePositionVariance"))
+        sourcePositionVariance_ = ReadVector2(source, "sourcePositionVariance");
+
+
+    if(source.HasChild("speed"))
+        speed_ = ReadFloat(source, "speed");
+
+    if(source.HasChild("speedVariance"))
+        speedVariance_ = ReadFloat(source, "speedVariance");
+
+
+    if(source.HasChild("particleLifeSpan"))
+        particleLifeSpan_ = Max(0.01f, ReadFloat(source, "particleLifeSpan"));
+
+    if(source.HasChild("particleLifespanVariance"))
+        particleLifespanVariance_ = ReadFloat(source, "particleLifespanVariance");
+
+
+    if(source.HasChild("angle"))
+        angle_ = ReadFloat(source, "angle");
+    if(source.HasChild("angleVariance"))
+        angleVariance_ = ReadFloat(source, "angleVariance");
+
+
+    if(source.HasChild("gravity"))
+        gravity_ = ReadVector2(source, "gravity");
+
+
+    if(source.HasChild("radialAcceleration"))
+        radialAcceleration_ = ReadFloat(source, "radialAcceleration");
+
+    if(source.HasChild("tangentialAcceleration"))
+        tangentialAcceleration_ = ReadFloat(source, "tangentialAcceleration");
+
+
+    if(source.HasChild("radialAccelVariance"))
+        radialAccelVariance_ = ReadFloat(source, "radialAccelVariance");
+
+    if(source.HasChild("tangentialAccelVariance"))
+        tangentialAccelVariance_ = ReadFloat(source, "tangentialAccelVariance");
+
+
+    if(source.HasChild("startColor"))
+        startColor_ = ReadColor(source, "startColor");
+
+    if(source.HasChild("startColorVariance"))
+        startColorVariance_ = ReadColor(source, "startColorVariance");
+
+
+    if(source.HasChild("finishColor"))
+        finishColor_ = ReadColor(source, "finishColor");
+
+    if(source.HasChild("finishColorVariance"))
+        finishColorVariance_ = ReadColor(source, "finishColorVariance");
+
+
+    if(source.HasChild("maxParticles"))
+        maxParticles_ = ReadInt(source, "maxParticles");
+
+
+    if(source.HasChild("startParticleSize"))
+        startParticleSize_ = ReadFloat(source, "startParticleSize");
+
+    if(source.HasChild("startParticleSizeVariance"))
+        startParticleSizeVariance_ = ReadFloat(source, "startParticleSizeVariance");
+
+
+    if(source.HasChild("finishParticleSize"))
+        finishParticleSize_ = ReadFloat(source, "finishParticleSize");
+
+    // Typo in pex file
+    if(source.HasChild("FinishParticleSizeVariance"))
+        finishParticleSizeVariance_ = ReadFloat(source, "FinishParticleSizeVariance");
+
+    if (source.HasChild("duration"))
+    {
+        float duration = ReadFloat(source, "duration");
+        if (duration > 0.0f)
+            duration_ = duration;
+    }
+
+
+    if(source.HasChild("emitterType"))
+        emitterType_ = (EmitterType2D)ReadInt(source, "emitterType");
+
+
+    if(source.HasChild("maxRadius"))
+        maxRadius_ = ReadFloat(source, "maxRadius");
+
+    if(source.HasChild("maxRadiusVariance"))
+        maxRadiusVariance_ = ReadFloat(source, "maxRadiusVariance");
+
+    if(source.HasChild("minRadius"))
+        minRadius_ = ReadFloat(source, "minRadius");
+
+    if(source.HasChild("minRadiusVariance"))
+        minRadiusVariance_ = ReadFloat(source, "minRadiusVariance");
+
+
+    if(source.HasChild("rotatePerSecond"))
+        rotatePerSecond_ = ReadFloat(source, "rotatePerSecond");
+
+    if(source.HasChild("rotatePerSecondVariance"))
+        rotatePerSecondVariance_ = ReadFloat(source, "rotatePerSecondVariance");
+
+    if(source.HasChild("blendFuncSource") && source.HasChild("blendFuncDestination"))
+    {
+        int blendFuncSource = ReadInt(source, "blendFuncSource");
+        int blendFuncDestination = ReadInt(source, "blendFuncDestination");
+        for (int i = 0; i < MAX_BLENDMODES; ++i)
+        {
+            if (blendFuncSource == srcBlendFuncs[i] && blendFuncDestination == destBlendFuncs[i])
+            {
+                blendMode_ = (BlendMode)i;
+                break;
+            }
+        }
+    }
+
+    if(source.HasChild("rotationStart"))
+        rotationStart_ = ReadFloat(source, "rotationStart");
+
+    if(source.HasChild("rotationStartVariance"))
+        rotationStartVariance_ = ReadFloat(source, "rotationStartVariance");
+
+    if(source.HasChild("rotationEnd"))
+        rotationEnd_ = ReadFloat(source, "rotationEnd");
+
+    if(source.HasChild("rotationEndVariance"))
+        rotationEndVariance_ = ReadFloat(source, "rotationEndVariance");
+
+    return true;
 }
 
 void ParticleEffect2D::SetSprite(Sprite2D* sprite)

--- a/Source/Urho3D/Urho2D/ParticleEffect2D.h
+++ b/Source/Urho3D/Urho2D/ParticleEffect2D.h
@@ -61,6 +61,13 @@ public:
     /// Save resource. Return true if successful.
     bool Save(Serializer& dest) const override;
 
+    using Resource::Load;
+
+    /// Save resource to XMLElement. Return true if successful.
+    bool Save(XMLElement& dest) const;
+    /// Load resource from XMLElement synchronously. Return true if successful.
+    bool Load(const XMLElement& source);
+
     /// Set sprite.
     void SetSprite(Sprite2D* sprite);
     /// Set source position variance.

--- a/Source/Urho3D/Urho2D/ParticleEmitter2D.cpp
+++ b/Source/Urho3D/Urho2D/ParticleEmitter2D.cpp
@@ -137,6 +137,25 @@ void ParticleEmitter2D::SetMaxParticles(unsigned maxParticles)
     numParticles_ = Min(maxParticles, numParticles_);
 }
 
+void ParticleEmitter2D::ResetEmissionTimer()
+{
+    emitParticleTime_ = 0.0f;
+    if(effect_) emissionTime_ = effect_->GetDuration();
+}
+
+void ParticleEmitter2D::RemoveAllParticles()
+{
+    for (auto i = particles_.Begin(); i != particles_.End(); ++i)
+        i->timeToLive_ = 0.0f;
+}
+
+void ParticleEmitter2D::Reset()
+{
+    RemoveAllParticles();
+    ResetEmissionTimer();
+    SetEmitting(true);
+}
+
 ParticleEffect2D* ParticleEmitter2D::GetEffect() const
 {
     return effect_;
@@ -171,7 +190,7 @@ void ParticleEmitter2D::SetEmitting(bool enable)
         return;
 
     emitting_ = enable;
-    emitParticleTime_ = 0.0f;
+    ResetEmissionTimer();
 
     MarkNetworkUpdate();
 }

--- a/Source/Urho3D/Urho2D/ParticleEmitter2D.h
+++ b/Source/Urho3D/Urho2D/ParticleEmitter2D.h
@@ -103,6 +103,12 @@ public:
     /// Set whether should be emitting. If the state was changed, also resets the emission period timer.
     /// @property
     void SetEmitting(bool enable);
+    /// Reset the emission period timer.
+    void ResetEmissionTimer();
+    /// Sets time left of all current particles to zero.
+    void RemoveAllParticles();
+    /// Reset the particle emitter completely. Removes current particles, sets emitting state on, and resets the emission timer.
+    void Reset();
 
     /// Return particle effect.
     /// @property

--- a/bin/Data/Scripts/Editor.as
+++ b/bin/Data/Scripts/Editor.as
@@ -8,6 +8,7 @@
 #include "Scripts/Editor/EditorGizmo.as"
 #include "Scripts/Editor/EditorMaterial.as"
 #include "Scripts/Editor/EditorParticleEffect.as"
+#include "Scripts/Editor/EditorParticle2D.as"
 #include "Scripts/Editor/EditorSettings.as"
 #include "Scripts/Editor/EditorPreferences.as"
 #include "Scripts/Editor/EditorToolBar.as"
@@ -163,6 +164,8 @@ void HandleUpdate(StringHash eventType, VariantMap& eventData)
             }
         }
     }
+
+    UpdateParticleEffect2dWindow(timeStep);
 }
 
 void HandleReloadFinishOrFail(StringHash eventType, VariantMap& eventData)

--- a/bin/Data/Scripts/Editor/AttributeEditor.as
+++ b/bin/Data/Scripts/Editor/AttributeEditor.as
@@ -1192,7 +1192,7 @@ void InitResourcePicker()
     resourcePickers.Push(ResourcePicker("JSONFile", "*.json"));
     resourcePickers.Push(ResourcePicker("Sprite2D", textureFilters, ACTION_PICK | ACTION_OPEN));
     resourcePickers.Push(ResourcePicker("AnimationSet2D", anmSetFilters, ACTION_PICK | ACTION_OPEN));
-    resourcePickers.Push(ResourcePicker("ParticleEffect2D", pexFilters, ACTION_PICK | ACTION_OPEN));
+    resourcePickers.Push(ResourcePicker("ParticleEffect2D", pexFilters, ACTION_PICK | ACTION_OPEN | ACTION_EDIT));
     resourcePickers.Push(ResourcePicker("TmxFile2D", tmxFilters, ACTION_PICK | ACTION_OPEN));
 }
 

--- a/bin/Data/Scripts/Editor/EditorActions.as
+++ b/bin/Data/Scripts/Editor/EditorActions.as
@@ -1013,6 +1013,45 @@ class EditParticleEffectAction : EditAction
     }
 }
 
+class EditParticleEffect2dAction : EditAction
+{
+    XMLFile@ oldState;
+    XMLFile@ newState;
+    WeakHandle particleEffect;
+    ParticleEmitter2D@ particleEmitter;
+
+    void Define(ParticleEmitter2D@ particleEmitter_, ParticleEffect2D@ particleEffect_, XMLFile@ oldState_)
+    {
+        particleEmitter = particleEmitter_;
+        particleEffect = particleEffect_;
+        oldState = oldState_;
+        newState = XMLFile();
+
+        XMLElement particleElem = newState.CreateRoot("particleEmitterConfig");
+        particleEffect_.Save(particleElem);
+    }
+
+    void Undo()
+    {
+        ParticleEffect2D@ effect = particleEffect.Get();
+        if (effect !is null)
+        {
+            effect.Load(oldState.root);
+            RefreshParticleEffectEditor2d();
+        }
+    }
+
+    void Redo()
+    {
+        ParticleEffect2D@ effect = particleEffect.Get();
+        if (effect !is null)
+        {
+            effect.Load(newState.root);
+            RefreshParticleEffectEditor2d();
+        }
+    }
+}
+
 class AssignMaterialAction : EditAction
 {
     WeakHandle model;

--- a/bin/Data/Scripts/Editor/EditorParticle2D.as
+++ b/bin/Data/Scripts/Editor/EditorParticle2D.as
@@ -1,0 +1,1391 @@
+// Urho3D particle 2d editor
+
+Window@ particleEffect2dWindow;
+ParticleEffect2D@ editParticleEffect2d;
+XMLFile@ oldParticleEffect2dState;
+bool inParticle2dEffectRefresh = false;
+View3D@ particle2dEffectPreview;
+Camera@ particle2dPreviewCamera;
+Scene@ particle2dPreviewScene;
+Node@ particle2dEffectPreviewNode;
+Node@ particle2dEffectPreviewGizmoNode;
+Node@ particle2dEffectPreviewGridNode;
+CustomGeometry@ particle2dEffectPreviewGrid;
+Node@ particle2dPreviewCameraNode;
+Node@ particle2dPreviewLightNode;
+Light@ particle2dPreviewLight;
+ParticleEmitter2D@ particleEffect2dEmitter;
+float particle2dResetTimer;
+bool showParticle2dPreviewAxes = true;
+Vector3 particle2dViewCamDir;
+Vector3 particle2dViewCamRot;
+float particle2dViewCamDist;
+
+bool particle2dLoopEmission = true;
+
+float particle2dGizmoOffset = 0.1f;
+float particle2dGizmoOffsetX;
+float particle2dGizmoOffsetY;
+
+void CreateParticleEffectEditor2d()
+{
+    if (particleEffect2dWindow !is null)
+        return;
+
+    particleEffect2dWindow = LoadEditorUI("UI/EditorParticleEffect2DWindow.xml");
+    ui.root.AddChild(particleEffect2dWindow);
+    particleEffect2dWindow.opacity = uiMaxOpacity;
+
+    InitParticleEffectPreview2d();
+    InitParticleEffect2dBasicAttributes();
+    RefreshParticleEffectEditor2d();
+
+    int width = Min(ui.root.width - 60, 800);
+    int height = Min(ui.root.height - 60, 600);
+    particleEffect2dWindow.SetSize(width, height);
+    CenterDialog(particleEffect2dWindow);
+
+    HideParticleEffectEditor2d();
+
+    SubscribeToEvent(particleEffect2dWindow.GetChild("NewButton", true), "Released", "NewParticleEffect2d");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RevertButton", true), "Released", "RevertParticleEffect2d");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("SaveButton", true), "Released", "SaveParticleEffect2d");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("SaveAsButton", true), "Released", "SaveParticleEffect2dAs");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("CloseButton", true), "Released", "HideParticleEffectEditor2d");
+
+    SubscribeToEvent(particleEffect2dWindow.GetChild("Speed", true), "TextChanged", "EditParticleEffect2dSpeed");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("SpeedVariance", true), "TextChanged", "EditParticleEffect2dSpeed");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ParticleLifespan", true), "TextChanged", "EditParticleEffect2dParticleLifespan");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ParticleLifespanVariance", true), "TextChanged", "EditParticleEffect2dParticleLifespan");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ParticleAngle", true), "TextChanged", "EditParticleEffect2dParticleAngle");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ParticleAngleVariance", true), "TextChanged", "EditParticleEffect2dParticleAngle");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("GravityX", true), "TextChanged", "EditParticleEffect2dGravity");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("GravityY", true), "TextChanged", "EditParticleEffect2dGravity");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RadialAcceleration", true), "TextChanged", "EditParticleEffect2dRadialAcceleration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RadialAccelerationVariance", true), "TextChanged", "EditParticleEffect2dRadialAcceleration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("TangentialAcceleration", true), "TextChanged", "EditParticleEffect2dTangentialAcceleration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("TangentialAccelerationVariance", true), "TextChanged", "EditParticleEffect2dTangentialAcceleration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColor_R", true), "TextChanged", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColor_G", true), "TextChanged", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColor_B", true), "TextChanged", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColor_A", true), "TextChanged", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColorVariance_R", true), "TextChanged", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColorVariance_G", true), "TextChanged", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColorVariance_B", true), "TextChanged", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColorVariance_A", true), "TextChanged", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColor_R", true), "TextChanged", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColor_G", true), "TextChanged", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColor_B", true), "TextChanged", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColor_A", true), "TextChanged", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColorVariance_R", true), "TextChanged", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColorVariance_G", true), "TextChanged", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColorVariance_B", true), "TextChanged", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColorVariance_A", true), "TextChanged", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MaxNumParticles", true), "TextChanged", "EditParticleEffect2dMaxNumParticles");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("SourcePosVarianceX", true), "TextChanged", "EditParticleEffect2dSourcePosVariance");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("SourcePosVarianceY", true), "TextChanged", "EditParticleEffect2dSourcePosVariance");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartParticleSize", true), "TextChanged", "EditParticleEffect2dStartParticleSize");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartParticleSizeVariance", true), "TextChanged", "EditParticleEffect2dStartParticleSize");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndParticleSize", true), "TextChanged", "EditParticleEffect2dEndParticleSize");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndParticleSizeVariance", true), "TextChanged", "EditParticleEffect2dEndParticleSize");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("Duration", true), "TextChanged", "EditParticleEffect2dDuration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MinRadius", true), "TextChanged", "EditParticleEffect2dRadius");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MinRadiusVariance", true), "TextChanged", "EditParticleEffect2dRadius");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MaxRadius", true), "TextChanged", "EditParticleEffect2dRadius");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MaxRadiusVariance", true), "TextChanged", "EditParticleEffect2dRadius");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationPerSecond", true), "TextChanged", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationPerSecondVariance", true), "TextChanged", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationStart", true), "TextChanged", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationStartVariance", true), "TextChanged", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationEnd", true), "TextChanged", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationEndVariance", true), "TextChanged", "EditParticleEffect2dRotation");
+
+
+
+    SubscribeToEvent(particleEffect2dWindow.GetChild("Speed", true), "TextFinished", "EditParticleEffect2dSpeed");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("SpeedVariance", true), "TextFinished", "EditParticleEffect2dSpeed");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ParticleLifespan", true), "TextFinished", "EditParticleEffect2dParticleLifespan");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ParticleLifespanVariance", true), "TextFinished", "EditParticleEffect2dParticleLifespan");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ParticleAngle", true), "TextFinished", "EditParticleEffect2dParticleAngle");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ParticleAngleVariance", true), "TextFinished", "EditParticleEffect2dParticleAngle");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("GravityX", true), "TextFinished", "EditParticleEffect2dGravity");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("GravityY", true), "TextFinished", "EditParticleEffect2dGravity");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RadialAcceleration", true), "TextFinished", "EditParticleEffect2dRadialAcceleration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RadialAccelerationVariance", true), "TextFinished", "EditParticleEffect2dRadialAcceleration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("TangentialAcceleration", true), "TextFinished", "EditParticleEffect2dTangentialAcceleration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("TangentialAccelerationVariance", true), "TextFinished", "EditParticleEffect2dTangentialAcceleration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColor_R", true), "TextFinished", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColor_G", true), "TextFinished", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColor_B", true), "TextFinished", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColor_A", true), "TextFinished", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColorVariance_R", true), "TextFinished", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColorVariance_G", true), "TextFinished", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColorVariance_B", true), "TextFinished", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartColorVariance_A", true), "TextFinished", "EditParticleEffect2dStartColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColor_R", true), "TextFinished", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColor_G", true), "TextFinished", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColor_B", true), "TextFinished", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColor_A", true), "TextFinished", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColorVariance_R", true), "TextFinished", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColorVariance_G", true), "TextFinished", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColorVariance_B", true), "TextFinished", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndColorVariance_A", true), "TextFinished", "EditParticleEffect2dEndColor");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MaxNumParticles", true), "TextFinished", "EditParticleEffect2dMaxNumParticles");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("SourcePosVarianceX", true), "TextFinished", "EditParticleEffect2dSourcePosVariance");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("SourcePosVarianceY", true), "TextFinished", "EditParticleEffect2dSourcePosVariance");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartParticleSize", true), "TextFinished", "EditParticleEffect2dStartParticleSize");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("StartParticleSizeVariance", true), "TextFinished", "EditParticleEffect2dStartParticleSize");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndParticleSize", true), "TextFinished", "EditParticleEffect2dEndParticleSize");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EndParticleSizeVariance", true), "TextFinished", "EditParticleEffect2dEndParticleSize");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("Duration", true), "TextFinished", "EditParticleEffect2dDuration");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MinRadius", true), "TextFinished", "EditParticleEffect2dRadius");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MinRadiusVariance", true), "TextFinished", "EditParticleEffect2dRadius");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MaxRadius", true), "TextFinished", "EditParticleEffect2dRadius");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("MaxRadiusVariance", true), "TextFinished", "EditParticleEffect2dRadius");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationPerSecond", true), "TextFinished", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationPerSecondVariance", true), "TextFinished", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationStart", true), "TextFinished", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationStartVariance", true), "TextFinished", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationEnd", true), "TextFinished", "EditParticleEffect2dRotation");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("RotationEndVariance", true), "TextFinished", "EditParticleEffect2dRotation");
+
+    SubscribeToEvent(particleEffect2dWindow.GetChild("EmitterType", true), "ItemSelected", "EditParticleEffect2dEmitterType");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("BlendMode", true), "ItemSelected", "EditParticleEffect2dEmitterType");
+
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ResetViewport", true), "Released", "ParticleEffect2dResetViewport");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("ShowGrid", true), "Toggled", "ParticleEffect2dShowGrid");
+    SubscribeToEvent(particleEffect2dWindow.GetChild("LoopEmission", true), "Toggled", "ParticleEffect2dToggleLoopEmission");
+
+    SubscribeToEvent(particleEffect2dEmitter, "ParticlesEnd", "ParticleEmitter2dDoneEmitting");
+}
+
+void Particle2d_SetGizmoPosition()
+{
+    Vector3 screenPos = Vector3(particle2dGizmoOffsetX, particle2dGizmoOffsetY, 25.0);
+    Vector3 newPos = particle2dPreviewCamera.ScreenToWorldPoint(screenPos);
+    particle2dEffectPreviewGizmoNode.position = newPos;
+}
+
+void Particle2d_ResetCameraTransformation()
+{
+    particle2dPreviewCameraNode.position = Vector3(0, 0, -5);
+    particle2dPreviewCameraNode.LookAt(Vector3(0, 0, 0));
+    particle2dViewCamDir = -particle2dPreviewCameraNode.position;
+    
+    // Manually set initial rotation because eulerAngle always return 0 on first frame
+    particle2dViewCamRot = Vector3(0.0, 180.0, 0.0);
+
+    particle2dViewCamDist = particle2dViewCamDir.length;
+    particle2dViewCamDir.Normalize();
+}
+
+void ParticleEffect2dResetViewport(StringHash eventType, VariantMap& eventData)
+{
+    Particle2d_ResetCameraTransformation();
+    Particle2d_SetGizmoPosition();
+    particle2dEffectPreview.QueueUpdate();
+}
+
+void ParticleEffect2dShowGrid(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox@ element = eventData["Element"].GetPtr();
+    showParticle2dPreviewAxes = element.checked;
+    particle2dEffectPreviewGridNode.enabled = showParticle2dPreviewAxes;
+    particle2dEffectPreview.QueueUpdate();
+}
+
+void ParticleEffect2dToggleLoopEmission(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox@ element = eventData["Element"].GetPtr();
+    particle2dLoopEmission = element.checked;
+}
+
+
+void UpdateParticleEffect2dWindow(float timeStep)
+{
+    // Handle Particle Editor 2D looping.
+    if (particleEffect2dWindow !is null and particleEffect2dWindow.visible)
+    {
+        if (!particleEffect2dEmitter.emitting)
+        {
+            if (particle2dResetTimer == 0.0f)
+                particle2dResetTimer = editParticleEffect2d.GetDuration() + 0.2f;
+            else
+            {
+                particle2dResetTimer = Max(particle2dResetTimer - timeStep, 0.0f);
+                if (particle2dResetTimer <= 0.0001f && particle2dLoopEmission)
+                {
+                    particleEffect2dEmitter.emitting = true;
+                    particle2dResetTimer = 0.0f;
+                }
+            }
+        }
+    }
+}
+
+void ParticleEmitter2dDoneEmitting(StringHash eventType, VariantMap& eventData)
+{
+    particleEffect2dEmitter.emitting = false;
+}
+
+
+void InitParticleEffect2dBasicAttributes()
+{
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("Speed", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("SpeedVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("ParticleLifespan", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("ParticleLifespanVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("ParticleAngle", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("ParticleAngleVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("GravityX", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("GravityY", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("RadialAcceleration", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("RadialAccelerationVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("TangentialAcceleration", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("TangentialAccelerationVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartColor_R", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartColor_G", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartColor_B", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartColor_A", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartColorVariance_R", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartColorVariance_G", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartColorVariance_B", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartColorVariance_A", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndColor_R", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndColor_G", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndColor_B", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndColor_A", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndColorVariance_R", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndColorVariance_G", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndColorVariance_B", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndColorVariance_A", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("MaxNumParticles", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("SourcePosVarianceX", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("SourcePosVarianceY", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartParticleSize", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("StartParticleSizeVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndParticleSize", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("EndParticleSizeVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("Duration", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("MinRadius", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("MinRadiusVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("MaxRadius", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("MaxRadiusVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("RotationPerSecond", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("RotationPerSecondVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("RotationStart", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("RotationStartVariance", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("RotationEnd", true)));
+    CreateDragSlider(cast<LineEdit>(particleEffect2dWindow.GetChild("RotationEndVariance", true)));
+}
+
+void EditParticleEffect2dSpeed(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "Speed")
+        editParticleEffect2d.SetSpeed(element.text.ToFloat());
+
+    if (element.name == "SpeedVariance")
+        editParticleEffect2d.SetSpeedVariance(element.text.ToFloat());
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dParticleLifespan(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "ParticleLifespan"){
+        // base lifespan must always be above 0!
+        editParticleEffect2d.SetParticleLifeSpan(Max(0.01, element.text.ToFloat()));
+    }
+
+
+    if (element.name == "ParticleLifespanVariance")
+        editParticleEffect2d.SetParticleLifespanVariance(element.text.ToFloat());
+
+    RefreshParticleEffect2dEmitter();
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dParticleAngle(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "ParticleAngle")
+        editParticleEffect2d.SetAngle(element.text.ToFloat());
+
+    if (element.name == "ParticleAngleVariance")
+        editParticleEffect2d.SetAngleVariance(element.text.ToFloat());
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dStartParticleSize(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "StartParticleSize")
+        editParticleEffect2d.SetStartParticleSize(element.text.ToFloat());
+
+    if (element.name == "StartParticleSizeVariance")
+        editParticleEffect2d.SetStartParticleSizeVariance(element.text.ToFloat());
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dEndParticleSize(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "EndParticleSize")
+        editParticleEffect2d.SetFinishParticleSize(element.text.ToFloat());
+
+    if (element.name == "EndParticleSizeVariance")
+        editParticleEffect2d.SetFinishParticleSizeVariance(element.text.ToFloat());
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dDuration(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "Duration")
+    {
+        editParticleEffect2d.SetDuration(element.text.ToFloat());
+        RefreshParticleEffect2dEmitter();
+    }
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dRadius(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "MinRadius")
+        editParticleEffect2d.SetMinRadius(element.text.ToFloat());
+
+    if (element.name == "MinRadiusVariance")
+        editParticleEffect2d.SetMinRadiusVariance(element.text.ToFloat());
+
+    if (element.name == "MaxRadius")
+        editParticleEffect2d.SetMaxRadius(element.text.ToFloat());
+
+    if (element.name == "MaxRadiusVariance")
+        editParticleEffect2d.SetMaxRadiusVariance(element.text.ToFloat());
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dRotation(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "RotationPerSecond")
+        editParticleEffect2d.SetRotatePerSecond(element.text.ToFloat());
+
+    if (element.name == "RotationPerSecondVariance")
+        editParticleEffect2d.SetRotatePerSecondVariance(element.text.ToFloat());
+
+    if (element.name == "RotationStart")
+        editParticleEffect2d.SetRotationStart(element.text.ToFloat());
+
+    if (element.name == "RotationStartVariance")
+        editParticleEffect2d.SetRotationStartVariance(element.text.ToFloat());
+
+    if (element.name == "RotationEnd")
+        editParticleEffect2d.SetRotationEnd(element.text.ToFloat());
+
+    if (element.name == "RotationEndVariance")
+        editParticleEffect2d.SetRotationEndVariance(element.text.ToFloat());
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dGravity(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    Vector2 v = editParticleEffect2d.GetGravity();
+
+    if (element.name == "GravityX")
+        editParticleEffect2d.SetGravity(Vector2(element.text.ToFloat(), v.y));
+
+    if (element.name == "GravityY")
+        editParticleEffect2d.SetGravity(Vector2(v.x, element.text.ToFloat()));
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dSourcePosVariance(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    Vector2 v = editParticleEffect2d.GetSourcePositionVariance();
+
+    if (element.name == "SourcePosVarianceX")
+        editParticleEffect2d.SetSourcePositionVariance(Vector2(element.text.ToFloat(), v.y));
+
+    if (element.name == "SourcePosVarianceY")
+        editParticleEffect2d.SetSourcePositionVariance(Vector2(v.x, element.text.ToFloat()));
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dRadialAcceleration(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "RadialAcceleration")
+        editParticleEffect2d.SetRadialAcceleration(element.text.ToFloat());
+
+    if (element.name == "RadialAccelerationVariance")
+        editParticleEffect2d.SetRadialAccelVariance(element.text.ToFloat());
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dTangentialAcceleration(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "TangentialAcceleration")
+        editParticleEffect2d.SetTangentialAcceleration(element.text.ToFloat());
+
+    if (element.name == "TangentialAccelerationVariance")
+        editParticleEffect2d.SetTangentialAccelVariance(element.text.ToFloat());
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dMaxNumParticles(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "MaxNumParticles")
+    {
+        editParticleEffect2d.SetMaxParticles(element.text.ToInt());
+        RefreshParticleEffect2dEmitter();
+    }
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dStartColor(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    Color v = editParticleEffect2d.GetStartColor();
+    Color vVar = editParticleEffect2d.GetStartColorVariance();
+
+    if (element.name == "StartColor_R")
+        editParticleEffect2d.SetStartColor(Color(element.text.ToFloat(), v.g, v.b, v.a));
+
+    if (element.name == "StartColor_G")
+        editParticleEffect2d.SetStartColor(Color(v.r, element.text.ToFloat(), v.b, v.a));
+
+    if (element.name == "StartColor_B")
+        editParticleEffect2d.SetStartColor(Color(v.r, v.g, element.text.ToFloat(), v.a));
+
+    if (element.name == "StartColor_A")
+        editParticleEffect2d.SetStartColor(Color(v.r, v.g, v.b, element.text.ToFloat()));
+
+
+    if (element.name == "StartColorVariance_R")
+        editParticleEffect2d.SetStartColorVariance(Color(element.text.ToFloat(), vVar.g, vVar.b, vVar.a));
+
+    if (element.name == "StartColorVariance_G")
+        editParticleEffect2d.SetStartColorVariance(Color(vVar.r, element.text.ToFloat(), vVar.b, vVar.a));
+
+    if (element.name == "StartColorVariance_B")
+        editParticleEffect2d.SetStartColorVariance(Color(vVar.r, vVar.g, element.text.ToFloat(), vVar.a));
+
+    if (element.name == "StartColorVariance_A")
+        editParticleEffect2d.SetStartColorVariance(Color(vVar.r, vVar.g, vVar.b, element.text.ToFloat()));
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dEndColor(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    LineEdit@ element = eventData["Element"].GetPtr();
+
+    Color v = editParticleEffect2d.GetFinishColor();
+    Color vVar = editParticleEffect2d.GetFinishColorVariance();
+
+    if (element.name == "EndColor_R")
+        editParticleEffect2d.SetFinishColor(Color(element.text.ToFloat(), v.g, v.b, v.a));
+
+    if (element.name == "EndColor_G")
+        editParticleEffect2d.SetFinishColor(Color(v.r, element.text.ToFloat(), v.b, v.a));
+
+    if (element.name == "EndColor_B")
+        editParticleEffect2d.SetFinishColor(Color(v.r, v.g, element.text.ToFloat(), v.a));
+
+    if (element.name == "EndColor_A")
+        editParticleEffect2d.SetFinishColor(Color(v.r, v.g, v.b, element.text.ToFloat()));
+
+
+    if (element.name == "EndColorVariance_R")
+        editParticleEffect2d.SetFinishColorVariance(Color(element.text.ToFloat(), vVar.g, vVar.b, vVar.a));
+
+    if (element.name == "EndColorVariance_G")
+        editParticleEffect2d.SetFinishColorVariance(Color(vVar.r, element.text.ToFloat(), vVar.b, vVar.a));
+
+    if (element.name == "EndColorVariance_B")
+        editParticleEffect2d.SetFinishColorVariance(Color(vVar.r, vVar.g, element.text.ToFloat(), vVar.a));
+
+    if (element.name == "EndColorVariance_A")
+        editParticleEffect2d.SetFinishColorVariance(Color(vVar.r, vVar.g, vVar.b, element.text.ToFloat()));
+
+    EndParticleEffect2dEdit();
+}
+
+void EditParticleEffect2dEmitterType(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    BeginParticleEffect2dEdit();
+
+    DropDownList@ element = eventData["Element"].GetPtr();
+
+    if (element.name == "EmitterType")
+    {
+    switch (element.selection)
+    {
+        case 0:
+            editParticleEffect2d.SetEmitterType(EMITTER_TYPE_GRAVITY);
+            break;
+
+        case 1:
+            editParticleEffect2d.SetEmitterType(EMITTER_TYPE_RADIAL);
+            break;
+
+    }
+
+    RefreshEmitterTypeDependentElements();
+    }
+
+    if (element.name == "BlendMode")
+    {
+    switch (element.selection)
+    {
+        case 0:
+            editParticleEffect2d.SetBlendMode(BLEND_REPLACE);
+            break;
+
+        case 1:
+            editParticleEffect2d.SetBlendMode(BLEND_ADD);
+            break;
+
+        case 2:
+            editParticleEffect2d.SetBlendMode(BLEND_MULTIPLY);
+            break;
+
+        case 3:
+            editParticleEffect2d.SetBlendMode(BLEND_ALPHA);
+            break;
+
+        case 4:
+            editParticleEffect2d.SetBlendMode(BLEND_ADDALPHA);
+            break;
+
+        case 5:
+            editParticleEffect2d.SetBlendMode(BLEND_PREMULALPHA);
+            break;
+
+        case 6:
+            editParticleEffect2d.SetBlendMode(BLEND_INVDESTALPHA);
+            break;
+
+        case 7:
+            editParticleEffect2d.SetBlendMode(BLEND_SUBTRACT);
+            break;
+
+        case 8:
+            editParticleEffect2d.SetBlendMode(BLEND_SUBTRACTALPHA);
+            break;
+
+    }
+
+        RefreshParticleEffect2dEmitter();
+    }
+
+
+    EndParticleEffect2dEdit();
+}
+
+bool ToggleParticleEffectEditor2d()
+{
+    if (particleEffect2dWindow.visible == false)
+        ShowParticleEffectEditor2d();
+    else
+        HideParticleEffectEditor2d();
+    return true;
+}
+
+void ShowParticleEffectEditor2d()
+{
+    RefreshParticleEffectEditor2d();
+    particleEffect2dWindow.visible = true;
+    particleEffect2dWindow.BringToFront();
+}
+
+void HideParticleEffectEditor2d()
+{
+    if (particleEffect2dWindow !is null)
+        particleEffect2dWindow.visible = false;
+}
+
+void UpdateParticleEffect2dPreviewGrid()
+{
+    uint gridSize = 8;
+    uint gridSubdivisions = 3;
+
+    //particle2dEffectPreviewGridNode.scale = Vector3(gridScale, gridScale, gridScale);
+    uint size = uint(Floor(gridSize / 2) * 2);
+    float halfSizeScaled = size / 2;
+    float scale = 1.0;
+    uint subdivisionSize = uint(Pow(2.0f, float(gridSubdivisions)));
+
+    if (subdivisionSize > 0)
+    {
+        size *= subdivisionSize;
+        scale /= subdivisionSize;
+    }
+
+    uint halfSize = size / 2;
+
+    particle2dEffectPreviewGrid.BeginGeometry(0, LINE_LIST);
+    float lineOffset = -halfSizeScaled;
+    for (uint i = 0; i <= size; ++i)
+    {
+        bool lineCenter = i == halfSize;
+        bool lineSubdiv = !Equals(Mod(i, subdivisionSize), 0.0);
+
+        particle2dEffectPreviewGrid.DefineVertex(Vector3(lineOffset, halfSizeScaled, 0.0));
+        particle2dEffectPreviewGrid.DefineColor(lineCenter ? gridYColor : (lineSubdiv ? gridSubdivisionColor : gridColor));
+        particle2dEffectPreviewGrid.DefineVertex(Vector3(lineOffset, -halfSizeScaled, 0.0));
+        particle2dEffectPreviewGrid.DefineColor(lineCenter ? gridYColor : (lineSubdiv ? gridSubdivisionColor : gridColor));
+
+        particle2dEffectPreviewGrid.DefineVertex(Vector3(-halfSizeScaled, lineOffset, 0.0));
+        particle2dEffectPreviewGrid.DefineColor(lineCenter ? gridXColor : (lineSubdiv ? gridSubdivisionColor : gridColor));
+        particle2dEffectPreviewGrid.DefineVertex(Vector3(halfSizeScaled, lineOffset, 0.0));
+        particle2dEffectPreviewGrid.DefineColor(lineCenter ? gridXColor : (lineSubdiv ? gridSubdivisionColor : gridColor));
+
+        lineOffset  += scale;
+    }
+    particle2dEffectPreviewGrid.Commit();
+    
+}
+
+void InitParticleEffectPreview2d()
+{
+    particle2dPreviewScene = Scene("particle2dPreviewScene");
+    particle2dPreviewScene.CreateComponent("Octree");
+
+    Node@ zoneNode = particle2dPreviewScene.CreateChild("Zone");
+    Zone@ zone = zoneNode.CreateComponent("Zone");
+    zone.boundingBox = BoundingBox(-1000, 1000);
+    zone.ambientColor = Color(0.15, 0.15, 0.15);
+    zone.fogColor = Color(0, 0, 0);
+    zone.fogStart = 10.0;
+    zone.fogEnd = 1000.0;
+
+    particle2dPreviewCameraNode = particle2dPreviewScene.CreateChild("PreviewCamera");
+    particle2dPreviewCamera = particle2dPreviewCameraNode.CreateComponent("Camera");
+    particle2dPreviewCamera.nearClip = 0.1f;
+    particle2dPreviewCamera.farClip = 1000.0f;
+    particle2dPreviewCamera.fov = 45.0f;
+
+    particle2dPreviewLightNode = particle2dPreviewScene.CreateChild("particle2dPreviewLight");
+    particle2dPreviewLightNode.direction = Vector3(0.5, -0.5, 0.5);
+    particle2dPreviewLight = particle2dPreviewLightNode.CreateComponent("Light");
+    particle2dPreviewLight.lightType = LIGHT_DIRECTIONAL;
+    particle2dPreviewLight.specularIntensity = 0.5;
+
+    particle2dEffectPreviewNode = particle2dPreviewScene.CreateChild("PreviewEmitter");
+    particle2dEffectPreviewNode.rotation = Quaternion(0, 0, 0);
+    
+    Particle2d_ResetCameraTransformation();
+
+    particle2dEffectPreviewGizmoNode = particle2dPreviewScene.CreateChild("Gizmo");
+    StaticModel@ gizmo = particle2dEffectPreviewGizmoNode.CreateComponent("StaticModel");
+    gizmo.model = cache.GetResource("Model", "Models/Editor/Axes.mdl");
+    gizmo.materials[0] = cache.GetResource("Material", "Materials/Editor/RedUnlit.xml");
+    gizmo.materials[1] = cache.GetResource("Material", "Materials/Editor/GreenUnlit.xml");
+    gizmo.materials[2] = cache.GetResource("Material", "Materials/Editor/BlueUnlit.xml");
+    gizmo.occludee = false;
+
+    particle2dEffectPreviewGridNode = particle2dPreviewScene.CreateChild("Grid");
+    particle2dEffectPreviewGrid = particle2dEffectPreviewGridNode.CreateComponent("CustomGeometry");
+    particle2dEffectPreviewGrid.numGeometries = 1;
+    particle2dEffectPreviewGrid.material = cache.GetResource("Material", "Materials/VColUnlit.xml");
+    particle2dEffectPreviewGrid.viewMask = 0x80000000; // Editor raycasts use viewmask 0x7fffffff
+    particle2dEffectPreviewGrid.occludee = false;
+
+    UpdateParticleEffect2dPreviewGrid();
+
+    particleEffect2dEmitter = particle2dEffectPreviewNode.CreateComponent("ParticleEmitter2D");
+    editParticleEffect2d = CreateNewParticleEffect2d();
+    particleEffect2dEmitter.SetEffect(editParticleEffect2d);
+
+    particle2dEffectPreview = particleEffect2dWindow.GetChild("ParticleEffectPreview", true);
+    particle2dEffectPreview.SetView(particle2dPreviewScene, particle2dPreviewCamera);
+    particle2dEffectPreview.viewport.renderPath = renderPath;
+
+    SubscribeToEvent(particle2dEffectPreview, "DragMove", "NavigateParticleEffect2dPreview");
+    SubscribeToEvent(particle2dEffectPreview, "Resized", "ResizeParticleEffect2dPreview");
+}
+
+ParticleEffect2D@ CreateNewParticleEffect2d()
+{
+    ParticleEffect2D@ effect = ParticleEffect2D();
+    Sprite2D@ res = cache.GetResource("Sprite2D", "Urho2D/sun.png");
+    if (res is null)
+        log.Error("Could not load default sprite for new 2d particle effect.");
+
+    effect.SetSprite(res);
+    return effect;
+}
+
+void EditParticleEffect2d(ParticleEffect2D@ effect)
+{
+    if (effect is null)
+        return;
+
+    if (editParticleEffect2d !is null)
+        UnsubscribeFromEvent(editParticleEffect2d, "ReloadFinished");
+
+    if (!effect.name.empty)
+        cache.ReloadResource(effect);
+        
+    editParticleEffect2d = effect;
+    particleEffect2dEmitter.effect = editParticleEffect2d;
+    RefreshParticleEffect2dEmitter();
+
+    if (editParticleEffect2d !is null)
+        SubscribeToEvent(editParticleEffect2d, "ReloadFinished", "RefreshParticleEffectEditor2d");
+
+    ShowParticleEffectEditor2d();
+}
+
+void RefreshParticleEffect2dEmitter()
+{
+    if (editParticleEffect2d is null || particleEffect2dEmitter is null)
+        return;
+
+    particleEffect2dEmitter.SetSprite(editParticleEffect2d.GetSprite());
+    particleEffect2dEmitter.SetBlendMode(editParticleEffect2d.GetBlendMode());
+    particleEffect2dEmitter.SetMaxParticles(editParticleEffect2d.GetMaxParticles());
+
+    particleEffect2dEmitter.Reset();
+}
+
+void RefreshParticleEffectEditor2d()
+{
+    inParticle2dEffectRefresh = true;
+
+    RefreshParticleEffect2dPreview();
+    RefreshParticleEffect2dName();
+    RefreshParticleEffect2dSprite();
+    RefreshParticleEffect2dBasicAttributes();
+    RefreshEmitterTypeDependentElements();
+
+    inParticle2dEffectRefresh = false;
+}
+
+void RefreshParticleEffect2dPreview()
+{
+    if (particleEffect2dEmitter is null || editParticleEffect2d is null)
+        return;
+    cast<CheckBox>(particleEffect2dWindow.GetChild("ShowGrid", true)).checked = showParticle2dPreviewAxes;
+    cast<CheckBox>(particleEffect2dWindow.GetChild("LoopEmission", true)).checked = particle2dLoopEmission;
+    particleEffect2dEmitter.effect = editParticleEffect2d;
+    RefreshParticleEffect2dEmitter();
+    particle2dEffectPreview.QueueUpdate();
+}
+
+void RefreshParticleEffect2dName()
+{
+    UIElement@ container = particleEffect2dWindow.GetChild("NameContainer", true);
+    if (container is null)
+        return;
+        
+    container.RemoveAllChildren();
+
+    LineEdit@ nameEdit = CreateAttributeLineEdit(container, null, 0, 0);
+    if (editParticleEffect2d !is null)
+        nameEdit.text = editParticleEffect2d.name;
+    SubscribeToEvent(nameEdit, "TextFinished", "EditParticleEffect2dName");
+
+    Button@ pickButton = CreateResourcePickerButton(container, null, 0, 0, "smallButtonPick");
+    SubscribeToEvent(pickButton, "Released", "PickEditParticleEffect2d");
+}
+
+
+void RefreshParticleEffect2dBasicAttributes()
+{
+    if (editParticleEffect2d is null)
+        return;
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("Speed", true)).text = editParticleEffect2d.GetSpeed();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("SpeedVariance", true)).text = editParticleEffect2d.GetSpeedVariance();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("ParticleLifespan", true)).text = editParticleEffect2d.GetParticleLifeSpan();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("ParticleLifespanVariance", true)).text = editParticleEffect2d.GetParticleLifespanVariance();
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("ParticleAngle", true)).text = editParticleEffect2d.GetAngle();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("ParticleAngleVariance", true)).text = editParticleEffect2d.GetAngleVariance();
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("GravityX", true)).text = editParticleEffect2d.GetGravity().x;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("GravityY", true)).text = editParticleEffect2d.GetGravity().y;
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("RadialAcceleration", true)).text = editParticleEffect2d.GetRadialAcceleration();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("RadialAccelerationVariance", true)).text = editParticleEffect2d.GetRadialAccelVariance();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("TangentialAcceleration", true)).text = editParticleEffect2d.GetTangentialAcceleration();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("TangentialAccelerationVariance", true)).text = editParticleEffect2d.GetTangentialAccelVariance();
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartColor_R", true)).text = editParticleEffect2d.GetStartColor().r;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartColor_G", true)).text = editParticleEffect2d.GetStartColor().g;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartColor_B", true)).text = editParticleEffect2d.GetStartColor().b;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartColor_A", true)).text = editParticleEffect2d.GetStartColor().a;
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartColorVariance_R", true)).text = editParticleEffect2d.GetStartColorVariance().r;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartColorVariance_G", true)).text = editParticleEffect2d.GetStartColorVariance().g;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartColorVariance_B", true)).text = editParticleEffect2d.GetStartColorVariance().b;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartColorVariance_A", true)).text = editParticleEffect2d.GetStartColorVariance().a;
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndColor_R", true)).text = editParticleEffect2d.GetFinishColor().r;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndColor_G", true)).text = editParticleEffect2d.GetFinishColor().g;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndColor_B", true)).text = editParticleEffect2d.GetFinishColor().b;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndColor_A", true)).text = editParticleEffect2d.GetFinishColor().a;
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndColorVariance_R", true)).text = editParticleEffect2d.GetFinishColorVariance().r;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndColorVariance_G", true)).text = editParticleEffect2d.GetFinishColorVariance().g;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndColorVariance_B", true)).text = editParticleEffect2d.GetFinishColorVariance().b;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndColorVariance_A", true)).text = editParticleEffect2d.GetFinishColorVariance().a;
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("MaxNumParticles", true)).text = editParticleEffect2d.GetMaxParticles();
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("SourcePosVarianceX", true)).text = editParticleEffect2d.GetSourcePositionVariance().x;
+    cast<LineEdit>(particleEffect2dWindow.GetChild("SourcePosVarianceY", true)).text = editParticleEffect2d.GetSourcePositionVariance().y
+    ;
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartParticleSize", true)).text = editParticleEffect2d.GetStartParticleSize();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("StartParticleSizeVariance", true)).text = editParticleEffect2d.GetStartParticleSizeVariance();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndParticleSize", true)).text = editParticleEffect2d.GetFinishParticleSize();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("EndParticleSizeVariance", true)).text = editParticleEffect2d.GetFinishParticleSizeVariance();
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("Duration", true)).text = editParticleEffect2d.GetDuration();
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("MinRadius", true)).text = editParticleEffect2d.GetMinRadius();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("MinRadiusVariance", true)).text = editParticleEffect2d.GetMinRadiusVariance();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("MaxRadius", true)).text = editParticleEffect2d.GetMaxRadius();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("MaxRadiusVariance", true)).text = editParticleEffect2d.GetMaxRadiusVariance();
+
+    cast<LineEdit>(particleEffect2dWindow.GetChild("RotationPerSecond", true)).text = editParticleEffect2d.GetRotatePerSecond();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("RotationPerSecondVariance", true)).text = editParticleEffect2d.GetRotatePerSecondVariance();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("RotationStart", true)).text = editParticleEffect2d.GetRotationStart();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("RotationStartVariance", true)).text = editParticleEffect2d.GetRotationStartVariance();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("RotationEnd", true)).text = editParticleEffect2d.GetRotationEnd();
+    cast<LineEdit>(particleEffect2dWindow.GetChild("RotationEndVariance", true)).text = editParticleEffect2d.GetRotationEndVariance();
+
+    switch (editParticleEffect2d.GetEmitterType())
+    {
+        case EMITTER_TYPE_GRAVITY:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("EmitterType", true)).selection = 0;
+            break;
+        case EMITTER_TYPE_RADIAL:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("EmitterType", true)).selection = 1;
+            break;
+    }
+
+    switch (editParticleEffect2d.GetBlendMode())
+    {
+        case BLEND_REPLACE:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 0;
+            break;
+        case BLEND_ADD:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 1;
+            break;
+        case BLEND_MULTIPLY:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 2;
+            break;
+        case BLEND_ALPHA:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 3;
+            break;
+        case BLEND_ADDALPHA:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 4;
+            break;
+        case BLEND_PREMULALPHA:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 5;
+            break;
+        case BLEND_INVDESTALPHA:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 6;
+            break;
+        case BLEND_SUBTRACT:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 7;
+            break;
+        case BLEND_SUBTRACTALPHA:
+            cast<DropDownList>(particleEffect2dWindow.GetChild("BlendMode", true)).selection = 8;
+            break;
+    }
+}
+
+void RefreshEmitterTypeDependentElements()
+{
+    UIElement@ radialOnlyContent = particleEffect2dWindow.GetChild("RadialOnlyContent", true);
+    UIElement@ gravityOnlyContent = particleEffect2dWindow.GetChild("GravityOnlyContent", true);
+
+    if (editParticleEffect2d is null)
+    {
+        // gravity starts visible
+        radialOnlyContent.SetVisible(false);
+        gravityOnlyContent.SetVisible(true);
+        return;
+    }
+
+    switch (editParticleEffect2d.GetEmitterType())
+    {
+        case EMITTER_TYPE_GRAVITY:
+            radialOnlyContent.SetVisible(false);
+            gravityOnlyContent.SetVisible(true);
+            break;
+        case EMITTER_TYPE_RADIAL:
+            radialOnlyContent.SetVisible(true);
+            gravityOnlyContent.SetVisible(false);
+            break;
+    }
+
+    // force a layout update of the scroll view
+    radialOnlyContent.GetParent().SetHeight(0);
+}
+
+void RefreshParticleEffect2dSprite()
+{
+    UIElement@ container = particleEffect2dWindow.GetChild("ParticleSpriteContainer", true);
+    if (container is null)
+        return;
+
+    container.RemoveAllChildren();
+
+    LineEdit@ nameEdit = CreateAttributeLineEdit(container, null, 0, 0);
+    if (editParticleEffect2d !is null)
+    {
+        if (editParticleEffect2d.GetSprite() !is null)
+            nameEdit.text = editParticleEffect2d.GetSprite().name;
+        else
+        {
+            nameEdit.text = "";
+        }
+    }
+
+    SubscribeToEvent(nameEdit, "TextFinished", "EditParticleEffect2dSprite");
+
+    Button@ pickButton = CreateResourcePickerButton(container, null, 0, 0, "smallButtonPick");
+    SubscribeToEvent(pickButton, "Released", "PickEditParticleEffect2dSprite");
+}
+
+void NavigateParticleEffect2dPreview(StringHash eventType, VariantMap& eventData)
+{
+    int dx = eventData["DX"].GetInt();
+    int dy = eventData["DY"].GetInt();
+
+    if (particle2dEffectPreview.height > 0 && particle2dEffectPreview.width > 0)
+    {
+        if (!input.keyDown[KEY_LSHIFT])
+        {
+            particle2dViewCamRot.x -= dy * 20 * time.timeStep;
+            particle2dViewCamRot.y += dx * 20 * time.timeStep;
+            particle2dViewCamRot.x = Clamp(particle2dViewCamRot.x, -89.5, 89.5);
+        }
+        else
+        {
+            particle2dViewCamDist += dy * 1.5 * time.timeStep;
+            particle2dViewCamDist -= dx * 1.5 * time.timeStep;
+            particle2dViewCamDist = Max(particle2dViewCamDist, 0.2);
+        }
+        particle2dPreviewCameraNode.position = particle2dEffectPreviewNode.position +
+            Quaternion(particle2dViewCamRot.x, particle2dViewCamRot.y, 0) * particle2dViewCamDir * particle2dViewCamDist;
+        particle2dPreviewCameraNode.LookAt(particle2dEffectPreviewNode.position);
+
+        Particle2d_SetGizmoPosition();
+        particle2dEffectPreview.QueueUpdate();
+    }
+
+}
+
+void ResizeParticleEffect2dPreview(StringHash eventType, VariantMap& eventData)
+{
+    
+    float width = float(particle2dEffectPreview.width);
+    float height = float(particle2dEffectPreview.height);
+    
+    // Manually set aspect ratio because first frame is always returning aspect ratio of 1
+    float aspectRatio = width / height;
+    particle2dPreviewCamera.aspectRatio = aspectRatio;
+
+    particle2dGizmoOffsetX = particle2dGizmoOffset;
+    particle2dGizmoOffsetY = 1.0f - particle2dGizmoOffset * aspectRatio;
+
+    if(width > height)
+    {
+        aspectRatio = height / width;
+        particle2dGizmoOffsetY = 1.0f - particle2dGizmoOffset;
+        particle2dGizmoOffsetX = particle2dGizmoOffset * aspectRatio;
+    }
+
+    Particle2d_SetGizmoPosition();
+    particle2dEffectPreview.QueueUpdate();
+}
+
+void EditParticleEffect2dName(StringHash eventType, VariantMap& eventData)
+{
+    LineEdit@ nameEdit = eventData["Element"].GetPtr();
+    String newParticleEffectName = nameEdit.text.Trimmed();
+    if (!newParticleEffectName.empty && !(editParticleEffect2d !is null && newParticleEffectName == editParticleEffect2d.name))
+    {
+        ParticleEffect2D@ newParticleEffect = cache.GetResource("ParticleEffect2D", newParticleEffectName);
+        if (newParticleEffect !is null)
+            EditParticleEffect2d(newParticleEffect);
+    }
+}
+
+void PickEditParticleEffect2d()
+{
+    @resourcePicker = GetResourcePicker(StringHash("ParticleEffect2D"));
+    if (resourcePicker is null)
+        return;
+
+    String lastPath = resourcePicker.lastPath;
+    if (lastPath.empty)
+        lastPath = sceneResourcePath;
+    CreateFileSelector(localization.Get("Pick ") + resourcePicker.typeName, "OK", "Cancel", lastPath, resourcePicker.filters, resourcePicker.lastFilter, false);
+    SubscribeToEvent(uiFileSelector, "FileSelected", "PickEditParticleEffect2dDone");
+}
+
+void PickEditParticleEffect2dDone(StringHash eventType, VariantMap& eventData)
+{
+    StoreResourcePickerPath();
+    CloseFileSelector();
+
+    if (!eventData["OK"].GetBool())
+    {
+        @resourcePicker = null;
+        return;
+    }
+
+    String resourceName = eventData["FileName"].GetString();
+    Resource@ res = GetPickedResource(resourceName);
+
+    if (res !is null)
+        EditParticleEffect2d(cast<ParticleEffect2D>(res));
+
+    @resourcePicker = null;
+}
+
+void EditParticleEffect2dSprite(StringHash eventType, VariantMap& eventData)
+{
+    LineEdit@ nameEdit = eventData["Element"].GetPtr();
+    String newSpriteText = nameEdit.text.Trimmed();
+    if (!newSpriteText.empty && editParticleEffect2d !is null)
+    {
+        Sprite2D@ newSprite = cache.GetResource("Sprite2D", newSpriteText);
+        if (newSprite !is null)
+        {
+            editParticleEffect2d.SetSprite(newSprite);
+            RefreshParticleEffect2dSprite();
+            RefreshParticleEffect2dEmitter();
+        }
+    }
+}
+
+void PickEditParticleEffect2dSprite(StringHash eventType, VariantMap& eventData)
+{
+    @resourcePicker = GetResourcePicker(StringHash("Sprite2D"));
+    if (resourcePicker is null)
+        return;
+
+    String lastPath = resourcePicker.lastPath;
+    if (lastPath.empty)
+        lastPath = sceneResourcePath;
+    CreateFileSelector(localization.Get("Pick ") + resourcePicker.typeName, "OK", "Cancel", lastPath, resourcePicker.filters, resourcePicker.lastFilter, false);
+    SubscribeToEvent(uiFileSelector, "FileSelected", "PickEditParticleEffect2dSpriteDone");
+}
+
+void PickEditParticleEffect2dSpriteDone(StringHash eventType, VariantMap& eventData)
+{
+    StoreResourcePickerPath();
+    CloseFileSelector();
+
+    if (!eventData["OK"].GetBool())
+    {
+        @resourcePicker = null;
+        return;
+    }
+
+    String resourceName = eventData["FileName"].GetString();
+    Resource@ res = GetPickedResource(resourceName);
+
+    if (res !is null && editParticleEffect2d !is null)
+    {
+        editParticleEffect2d.SetSprite(res);
+        RefreshParticleEffect2dSprite();
+        RefreshParticleEffect2dEmitter();
+    }
+
+    @resourcePicker = null;
+}
+
+void NewParticleEffect2d()
+{
+    BeginParticleEffect2dEdit();
+
+    EditParticleEffect2d(CreateNewParticleEffect2d());
+    
+    EndParticleEffect2dEdit();
+}
+
+void RevertParticleEffect2d()
+{
+    if (inParticle2dEffectRefresh)
+        return;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    if (editParticleEffect2d.name.empty)
+    {
+        NewParticleEffect2d();
+        return;
+    }
+
+    BeginParticleEffect2dEdit();
+    
+    cache.ReloadResource(editParticleEffect2d);
+
+    EndParticleEffect2dEdit();
+    
+    RefreshParticleEffectEditor2d();
+}
+
+void SaveParticleEffect2d()
+{
+    if (editParticleEffect2d is null || editParticleEffect2d.name.empty)
+        return;
+
+    String fullName = cache.GetResourceFileName(editParticleEffect2d.name);
+    if (fullName.empty)
+        return;
+
+    File saveFile(fullName, FILE_WRITE);
+    editParticleEffect2d.Save(saveFile);
+}
+
+void SaveParticleEffect2dAs()
+{
+    if (editParticleEffect2d is null)
+        return;
+
+    @resourcePicker = GetResourcePicker(StringHash("ParticleEffect2D"));
+    if (resourcePicker is null)
+        return;
+
+    String lastPath = resourcePicker.lastPath;
+    if (lastPath.empty)
+        lastPath = sceneResourcePath;
+    CreateFileSelector("Save particle effect 2D as", "Save", "Cancel", lastPath, resourcePicker.filters, resourcePicker.lastFilter);
+    SubscribeToEvent(uiFileSelector, "FileSelected", "SaveParticleEffect2dAsDone");
+}
+
+void SaveParticleEffect2dAsDone(StringHash eventType, VariantMap& eventData)
+{
+    StoreResourcePickerPath();
+    CloseFileSelector();
+    @resourcePicker = null;
+
+    if (editParticleEffect2d is null)
+        return;
+
+    if (!eventData["OK"].GetBool())
+    {
+        @resourcePicker = null;
+        return;
+    }
+
+    String fullName = eventData["FileName"].GetString();
+
+    // Add default extension for saving if not specified
+    String filter = eventData["Filter"].GetString();
+    if (GetExtension(fullName).empty && filter != "*.*")
+        fullName = fullName + filter.Substring(1);
+
+    File saveFile(fullName, FILE_WRITE);
+    if (editParticleEffect2d.Save(saveFile))
+    {
+        saveFile.Close();
+
+        // Load the new resource to update the name in the editor
+        ParticleEffect2D@ newEffect = cache.GetResource("ParticleEffect2D", GetResourceNameFromFullName(fullName));
+        if (newEffect !is null)
+            EditParticleEffect2d(newEffect);
+    }
+}
+
+void BeginParticleEffect2dEdit()
+{
+    if (editParticleEffect2d is null)
+        return;
+
+    inParticle2dEffectRefresh = true;
+
+    oldParticleEffect2dState = XMLFile();
+    XMLElement particleElem = oldParticleEffect2dState.CreateRoot("particleEmitterConfig");
+    editParticleEffect2d.Save(particleElem);
+}
+
+void EndParticleEffect2dEdit()
+{
+    if (editParticleEffect2d is null)
+        return;
+
+    if (!dragEditAttribute)
+    {
+        EditParticleEffect2dAction@ action = EditParticleEffect2dAction();
+        action.Define(particleEffect2dEmitter, editParticleEffect2d, oldParticleEffect2dState);
+        SaveEditAction(action);
+    }
+
+    inParticle2dEffectRefresh = false;
+    
+    particle2dEffectPreview.QueueUpdate();
+}

--- a/bin/Data/Scripts/Editor/EditorResourceBrowser.as
+++ b/bin/Data/Scripts/Editor/EditorResourceBrowser.as
@@ -452,7 +452,7 @@ void HandleBrowserFileClick(StringHash eventType, VariantMap& eventData)
     {
         actions.Push(CreateBrowserFileActionMenu("Execute Script", "HandleBrowserRunScript", file));
     }
-    else if (file.resourceType == RESOURCE_TYPE_PARTICLEEFFECT || file.resourceType == RESOURCE_TYPE_PARTICLEEMITTER)
+    else if (file.resourceType == RESOURCE_TYPE_PARTICLEEFFECT || file.resourceType == RESOURCE_TYPE_PARTICLEEMITTER || file.resourceType == RESOURCE_TYPE_2D_PARTICLE_EFFECT)
     {
         actions.Push(CreateBrowserFileActionMenu("Edit", "HandleBrowserEditResource", file));
     }
@@ -903,6 +903,13 @@ void HandleBrowserEditResource(StringHash eventType, VariantMap& eventData)
         ParticleEffect@ particleEffect = cache.GetResource("ParticleEffect", file.resourceKey);
         if (particleEffect !is null)
             EditParticleEffect(particleEffect);
+    }
+
+    if (file.resourceType == RESOURCE_TYPE_2D_PARTICLE_EFFECT)
+    {
+        ParticleEffect2D@ particleEffect2d = cache.GetResource("ParticleEffect2D", file.resourceKey);
+        if (particleEffect2d !is null)
+            EditParticleEffect2d(particleEffect2d);
     }
 }
 

--- a/bin/Data/Scripts/Editor/EditorUI.as
+++ b/bin/Data/Scripts/Editor/EditorUI.as
@@ -89,6 +89,7 @@ void CreateUI()
     CreateEditorPreferencesDialog();
     CreateMaterialEditor();
     CreateParticleEffectEditor();
+    CreateParticleEffectEditor2d();
     CreateSpawnEditor();
     CreateSoundTypeEditor();
     CreateStatsBar();
@@ -534,6 +535,7 @@ void CreateMenuBar()
         popup.AddChild(CreateMenuItem("Resource browser", @ToggleResourceBrowserWindow, KEY_B, QUAL_CTRL));
         popup.AddChild(CreateMenuItem("Material editor", @ToggleMaterialEditor));
         popup.AddChild(CreateMenuItem("Particle editor", @ToggleParticleEffectEditor));
+        popup.AddChild(CreateMenuItem("2D Particle editor", @ToggleParticleEffectEditor2d));
         popup.AddChild(CreateMenuItem("Terrain editor", TerrainEditorShowCallback(terrainEditor.Show)));
         popup.AddChild(CreateMenuItem("Spawn editor", @ToggleSpawnEditor));
         popup.AddChild(CreateMenuItem("Duplicator editor", @ToggleDuplicatorEditor));

--- a/bin/Data/Translation/EditorStrings.json
+++ b/bin/Data/Translation/EditorStrings.json
@@ -395,6 +395,18 @@
 		"fr":"Éditeur de particules",
 		"it":"Editor particelle"
 	},
+	"Particle editor 2D":{
+		"en":"Particle editor 2D",
+		"ru":"Редактор частиц 2D",
+		"fr":"Éditeur de particules 2D",
+		"it":"Editor particelle 2D"
+	},
+	"2D Particle editor":{
+		"en":"Particle editor 2D",
+		"ru":"Редактор частиц 2D",
+		"fr":"Éditeur de particules 2D",
+		"it":"Editor particelle 2D"
+	},
 	"Spawn editor":{
 		"en":"Spawn editor",
 		"ru":"Редактор спауна",
@@ -965,6 +977,12 @@
 		"fr":"Sauvegarder l'effêt de particule comme",
 		"it":"Salva effetto particellare come"
 	},
+	"Save particle effect 2D as":{
+		"en":"Save particle effect 2D as",
+		"ru":"Сохранить эффект из частиц 2D как",
+		"fr":"Sauvegarder l'effêt de particule 2D comme",
+		"it":"Salva effetto particellare 2D come"
+	},
 	"Load":{
 		"en":"Load",
 		"ru":"Загрузить",
@@ -1391,6 +1409,12 @@
 		"fr":"Couleur",
 		"it":"Colore"
 	},
+	"Colors":{
+		"en":"Colors",
+		"ru":"Цвета",
+		"fr":"Couleurs",
+		"it":"Colori"
+	},
 	"Tags":{
 		"en":"Tags",
 		"ru":"Теги",
@@ -1431,5 +1455,20 @@
 		"en":"Keep camera preview after deselect",
 		"ru":"Сохранять предварительный просмотр камеры после снятия выделения",
 		"it":"Mantieni l'anteprima della camera dopo aver deselezionato"
+	},
+	"Loop Emission":{
+		"en":"Loop Emission",
+		"ru":"Цикл выбросов",
+		"it":"Emissione in ciclo"
+	},
+	"Gravity Emitter Config":{
+		"en":"Gravity Emitter Config",
+		"ru":"Конфигурация гравитационного излучателя",
+		"it":"Config. emettitore di gravità"
+	},
+	"Radial Emitter Config":{
+		"en":"Radial Emitter Config",
+		"ru":"Радиальная конфигурация излучателя",
+		"it":"Config. emettitore radiale"
 	}
 }

--- a/bin/Data/UI/EditorParticleEffect2DWindow.xml
+++ b/bin/Data/UI/EditorParticleEffect2DWindow.xml
@@ -1,0 +1,1248 @@
+<?xml version="1.0"?>
+<element type="Window">
+	<attribute name="Name" value="ParticleEffect2dWindow" />
+	<attribute name="Position" value="397 123" />
+	<attribute name="Size" value="794 384" />
+	<attribute name="Layout Mode" value="Vertical" />
+	<attribute name="Layout Spacing" value="4" />
+	<attribute name="Layout Border" value="6 6 6 6" />
+	<attribute name="Resize Border" value="6 6 6 6" />
+	<attribute name="Is Movable" value="true" />
+	<attribute name="Is Resizable" value="true" />
+	<element>
+		<attribute name="Min Size" value="0 16" />
+		<attribute name="Max Size" value="2147483647 16" />
+		<attribute name="Pivot" value="0 0" />
+		<attribute name="Layout Mode" value="Horizontal" />
+		<element type="Text">
+			<attribute name="Text" value="Particle editor 2D" />
+			<attribute name="Auto Localizable" value="true" />
+		</element>
+		<element type="Button" style="CloseButton">
+			<attribute name="Name" value="CloseButton" />
+			<attribute name="Border" value="4 4 4 4" />
+			<attribute name="Hover Image Offset" value="0 16" />
+			<attribute name="Pressed Image Offset" value="16 0" />
+		</element>
+	</element>
+	<element type="BorderImage" style="EditorDivider" />
+	<element>
+		<attribute name="Pivot" value="0 0" />
+		<attribute name="Layout Mode" value="Horizontal" />
+		<element>
+			<attribute name="Pivot" value="0 0" />
+			<attribute name="Layout Mode" value="Vertical" />
+			<element type="View3D" style="View3D">
+				<attribute name="Name" value="ParticleEffectPreview" />
+				<attribute name="Pivot" value="0 0" />
+				<attribute name="Use Derived Opacity" value="false" />
+				<attribute name="Image Rect" value="0 0 412 310" />
+			</element>
+			<element type="BorderImage" style="EditorDivider" />
+			<element>
+				<attribute name="Min Size" value="0 16" />
+				<attribute name="Max Size" value="2147483647 16" />
+				<attribute name="Pivot" value="0 0" />
+				<attribute name="Layout Mode" value="Horizontal" />
+				<attribute name="Layout Spacing" value="4" />
+				<element type="Button">
+					<attribute name="Name" value="ResetViewport" />
+					<attribute name="Layout Mode" value="Horizontal" />
+					<attribute name="Layout Border" value="1 1 1 1" />
+					<element type="Text">
+						<attribute name="Text" value="Reset Viewport" />
+						<attribute name="Text Alignment" value="Center" />
+						<attribute name="Auto Localizable" value="true" />
+					</element>
+				</element>
+				<element type="BorderImage" style="EditorVerticalDivider" />
+				<element>
+					<attribute name="Min Size" value="0 16" />
+					<attribute name="Max Size" value="2147483647 16" />
+					<attribute name="Pivot" value="0 0" />
+					<attribute name="Layout Mode" value="Horizontal" />
+					<attribute name="Layout Spacing" value="10" />
+					<element type="Text" style="EditorAttributeText">
+						<attribute name="Pivot" value="0 0" />
+						<attribute name="Text" value="Show Grid" />
+						<attribute name="Auto Localizable" value="true" />
+					</element>
+					<element>
+						<attribute name="Min Size" value="0 16" />
+						<attribute name="Max Size" value="2147483647 16" />
+						<attribute name="Pivot" value="0 0" />
+						<attribute name="Layout Mode" value="Horizontal" />
+						<attribute name="Layout Spacing" value="1" />
+						<element type="CheckBox">
+							<attribute name="Name" value="ShowGrid" />
+						</element>
+					</element>
+				</element>
+				<element type="BorderImage" style="EditorVerticalDivider" />
+				<element>
+					<attribute name="Min Size" value="0 16" />
+					<attribute name="Max Size" value="2147483647 16" />
+					<attribute name="Pivot" value="0 0" />
+					<attribute name="Layout Mode" value="Horizontal" />
+					<attribute name="Layout Spacing" value="10" />
+					<element type="Text" style="EditorAttributeText">
+						<attribute name="Pivot" value="0 0" />
+						<attribute name="Text" value="Loop Emission" />
+						<attribute name="Auto Localizable" value="true" />
+					</element>
+					<element>
+						<attribute name="Min Size" value="0 16" />
+						<attribute name="Max Size" value="2147483647 16" />
+						<attribute name="Pivot" value="0 0" />
+						<attribute name="Layout Mode" value="Horizontal" />
+						<attribute name="Layout Spacing" value="1" />
+						<element type="CheckBox">
+							<attribute name="Name" value="LoopEmission" />
+							<attribute name="Is Checked" value="true" />
+						</element>
+					</element>
+				</element>
+			</element>
+		</element>
+		<element type="BorderImage" style="EditorVerticalDivider" />
+		<element>
+			<attribute name="Pivot" value="0 0" />
+			<attribute name="Layout Mode" value="Vertical" />
+			<element>
+				<attribute name="Name" value="NameContainer" />
+				<attribute name="Min Size" value="0 16" />
+				<attribute name="Max Size" value="2147483647 16" />
+				<attribute name="Pivot" value="0 0" />
+				<attribute name="Layout Mode" value="Horizontal" />
+			</element>
+			<element type="BorderImage" style="EditorDivider" />
+			<element type="ListView" style="PanelView">
+				<attribute name="Min Size" value="0 60" />
+				<attribute name="Pivot" value="0 0" />
+				<element type="ScrollBar" internal="true" style="none">
+					<attribute name="Size" value="343 16" />
+					<attribute name="Min Anchor" value="0 1" />
+					<attribute name="Max Anchor" value="0 1" />
+					<attribute name="Pivot" value="0 1" />
+					<attribute name="Color" value="0 0 0 0" />
+					<attribute name="Top Left Color" value="0 0 0 0" />
+					<attribute name="Top Right Color" value="0 0 0 0" />
+					<attribute name="Bottom Left Color" value="0 0 0 0" />
+					<attribute name="Bottom Right Color" value="0 0 0 0" />
+					<element type="Button" internal="true" style="none">
+						<attribute name="Size" value="16 16" />
+						<attribute name="Border" value="4 4 4 4" />
+						<attribute name="Hover Image Offset" value="0 16" />
+						<attribute name="Pressed Image Offset" value="64 0" />
+					</element>
+					<element type="Slider" internal="true" style="none">
+						<attribute name="Position" value="16 0" />
+						<attribute name="Size" value="311 16" />
+						<attribute name="Image Rect" value="64 0 80 16" />
+						<attribute name="Border" value="4 4 4 4" />
+						<element type="BorderImage" internal="true" style="none">
+							<attribute name="Image Rect" value="16 0 32 16" />
+							<attribute name="Border" value="4 4 4 4" />
+							<attribute name="Hover Image Offset" value="0 16" />
+						</element>
+					</element>
+					<element type="Button" internal="true" style="none">
+						<attribute name="Position" value="327 0" />
+						<attribute name="Size" value="16 16" />
+						<attribute name="Border" value="4 4 4 4" />
+						<attribute name="Hover Image Offset" value="0 16" />
+						<attribute name="Pressed Image Offset" value="64 0" />
+					</element>
+				</element>
+				<element type="ScrollBar" internal="true" style="none">
+					<attribute name="Size" value="16 283" />
+					<attribute name="Min Anchor" value="1 0" />
+					<attribute name="Max Anchor" value="1 0" />
+					<attribute name="Pivot" value="1 0" />
+					<attribute name="Color" value="0 0 0 0" />
+					<attribute name="Top Left Color" value="0 0 0 0" />
+					<attribute name="Top Right Color" value="0 0 0 0" />
+					<attribute name="Bottom Left Color" value="0 0 0 0" />
+					<attribute name="Bottom Right Color" value="0 0 0 0" />
+					<element type="Button" internal="true" style="none">
+						<attribute name="Size" value="16 16" />
+						<attribute name="Border" value="4 4 4 4" />
+						<attribute name="Hover Image Offset" value="0 16" />
+						<attribute name="Pressed Image Offset" value="64 0" />
+					</element>
+					<element type="Slider" internal="true" style="none">
+						<attribute name="Position" value="0 16" />
+						<attribute name="Size" value="16 251" />
+						<attribute name="Image Rect" value="64 0 80 16" />
+						<attribute name="Border" value="4 4 4 4" />
+						<element type="BorderImage" internal="true" style="none">
+							<attribute name="Image Rect" value="16 0 32 16" />
+							<attribute name="Border" value="4 4 4 4" />
+							<attribute name="Hover Image Offset" value="0 16" />
+						</element>
+					</element>
+					<element type="Button" internal="true" style="none">
+						<attribute name="Position" value="0 267" />
+						<attribute name="Size" value="16 16" />
+						<attribute name="Border" value="4 4 4 4" />
+						<attribute name="Hover Image Offset" value="0 16" />
+						<attribute name="Pressed Image Offset" value="64 0" />
+					</element>
+				</element>
+				<element type="BorderImage" internal="true" style="none">
+					<attribute name="Clip Border" value="2 2 2 2" />
+					<attribute name="Image Rect" value="64 16 80 32" />
+					<attribute name="Border" value="4 4 4 4" />
+					<element internal="true" style="none">
+						<attribute name="Pivot" value="0 0" />
+						<attribute name="Layout Spacing" value="4" />
+						<attribute name="Layout Border" value="4 4 4 4" />
+						<element style="Panel">
+							<attribute name="Pivot" value="0 0" />
+							<element type="Text">
+								<attribute name="Text" value="Initial" />
+								<attribute name="Auto Localizable" value="true" />
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Active Duration" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="Duration" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Particle Lifespan" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="ParticleLifespan" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Lifespan Variance" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="ParticleLifespanVariance" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Angle" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="ParticleAngle" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Angle Variance" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="ParticleAngleVariance" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element type="BorderImage" style="EditorDivider" />
+						<element style="Panel">
+							<attribute name="Pivot" value="0 0" />
+							<element type="Text">
+								<attribute name="Text" value="Colors" />
+								<attribute name="Auto Localizable" value="true" />
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Start Color" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="StartColor_R" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="StartColor_G" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="StartColor_B" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="StartColor_A" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Start Color Variance" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="StartColorVariance_R" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="StartColorVariance_G" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="StartColorVariance_B" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="StartColorVariance_A" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="End Color" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="EndColor_R" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="EndColor_G" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="EndColor_B" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="EndColor_A" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="End Color Variance" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="EndColorVariance_R" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="EndColorVariance_G" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="EndColorVariance_B" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+								<element type="LineEdit">
+									<attribute name="Name" value="EndColorVariance_A" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element type="BorderImage" style="EditorDivider" />
+						<element style="Panel">
+							<attribute name="Pivot" value="0 0" />
+							<element type="Text">
+								<attribute name="Text" value="Renderer" />
+								<attribute name="Auto Localizable" value="true" />
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Max Num. Particles" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="MaxNumParticles" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element style="Panel">
+							<attribute name="Pivot" value="0 0" />
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Sprite" />
+								</element>
+								<element>
+									<attribute name="Name" value="ParticleSpriteContainer" />
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Blend Mode" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="DropDownList">
+									<attribute name="Name" value="BlendMode" />
+									<attribute name="Selection" value="-1" />
+									<element internal="true" style="none">
+										<attribute name="Pivot" value="0 0" />
+										<element type="Text" internal="true" style="none" />
+									</element>
+									<element popup="true" type="Window" internal="true" style="none">
+										<attribute name="Priority" value="2147483647" />
+										<attribute name="Layout Border" value="2 4 2 4" />
+										<attribute name="Image Rect" value="48 0 64 16" />
+										<attribute name="Border" value="4 4 4 4" />
+										<attribute name="Resize Border" value="8 8 8 8" />
+										<element type="ListView" internal="true" style="none">
+											<attribute name="Pivot" value="0 0" />
+											<attribute name="Highlight Mode" value="Always" />
+											<element type="BorderImage" internal="true" style="none">
+												<attribute name="Clip Border" value="2 0 2 0" />
+												<attribute name="Opacity" value="0" />
+												<attribute name="Image Rect" value="64 16 80 32" />
+												<attribute name="Border" value="4 4 4 4" />
+												<element internal="true" style="none">
+													<attribute name="Pivot" value="0 0" />
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_REPLACE" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_ADD" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_MULTIPLY" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_ALPHA" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_ADDALPHA" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_PREMULALPHA" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_INVDESTALPHA" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_SUBTRACT" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="BLEND_SUBTRACTALPHA" />
+													</element>
+												</element>
+											</element>
+										</element>
+									</element>
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Start Particle Size" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="StartParticleSize" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Start Particle Size Var." />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="StartParticleSizeVariance" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="End Particle Size" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="EndParticleSize" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="End Particle Size Var." />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="EndParticleSizeVariance" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Rotation Start" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="RotationStart" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Rotation Start Var." />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="RotationStartVariance" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Rotation End" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="RotationEnd" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Rotation End Var." />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="LineEdit">
+									<attribute name="Name" value="RotationEndVariance" />
+									<element type="Text" internal="true" style="none" />
+									<element type="BorderImage" internal="true" style="none" />
+								</element>
+							</element>
+						</element>
+						<element>
+							<attribute name="Min Size" value="0 16" />
+							<attribute name="Max Size" value="2147483647 16" />
+							<attribute name="Pivot" value="0 0" />
+							<attribute name="Layout Mode" value="Horizontal" />
+							<attribute name="Layout Spacing" value="10" />
+							<element type="Text" style="EditorAttributeText">
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Text" value="Emitter Type" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="1" />
+								<element type="DropDownList">
+									<attribute name="Name" value="EmitterType" />
+									<attribute name="Resize Popup" value="true" />
+									<element internal="true" style="none">
+										<attribute name="Pivot" value="0 0" />
+										<element type="Text" internal="true" style="none" />
+									</element>
+									<element popup="true" type="Window" internal="true" style="none">
+										<attribute name="Priority" value="2147483647" />
+										<attribute name="Layout Border" value="2 4 2 4" />
+										<attribute name="Image Rect" value="48 0 64 16" />
+										<attribute name="Border" value="4 4 4 4" />
+										<attribute name="Resize Border" value="8 8 8 8" />
+										<element type="ListView" internal="true" style="none">
+											<attribute name="Pivot" value="0 0" />
+											<attribute name="View Position" value="0 16" />
+											<attribute name="Highlight Mode" value="Always" />
+											<element type="BorderImage" internal="true" style="none">
+												<attribute name="Clip Border" value="2 0 2 0" />
+												<attribute name="Opacity" value="0" />
+												<attribute name="Image Rect" value="64 16 80 32" />
+												<attribute name="Border" value="4 4 4 4" />
+												<element internal="true" style="none">
+													<attribute name="Pivot" value="0 0" />
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Is Selected" value="true" />
+														<attribute name="Text" value="Gravity" />
+													</element>
+													<element type="Text" style="FileSelectorFilterText">
+														<attribute name="Text" value="Radial" />
+													</element>
+												</element>
+											</element>
+										</element>
+									</element>
+								</element>
+							</element>
+						</element>
+						<element style="Panel">
+							<attribute name="Name" value="GravityOnlyContent" />
+							<attribute name="Pivot" value="0 0" />
+							<element type="Text">
+								<attribute name="Text" value="Gravity Emitter Config" />
+								<attribute name="Auto Localizable" value="true" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Speed" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="Speed" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Speed Variance" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="SpeedVariance" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Gravity" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="GravityX" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+									<element type="LineEdit">
+										<attribute name="Name" value="GravityY" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Radial Acceleration" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="RadialAcceleration" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Radial Accel. Variance" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="RadialAccelerationVariance" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Tangent Acceleration" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="TangentialAcceleration" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Tangent Accel. Variance" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="TangentialAccelerationVariance" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Source Pos Variance" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="SourcePosVarianceX" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+									<element type="LineEdit">
+										<attribute name="Name" value="SourcePosVarianceY" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+						</element>
+						<element style="Panel">
+							<attribute name="Name" value="RadialOnlyContent" />
+							<attribute name="Pivot" value="0 0" />
+							<element type="Text">
+								<attribute name="Text" value="Radial Emitter Config" />
+								<attribute name="Auto Localizable" value="true" />
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Rotation Speed" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="RotationPerSecond" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Rotation Speed Var." />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="RotationPerSecondVariance" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Min Radius" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="MinRadius" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Min Radius Variance" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="MinRadiusVariance" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Max Radius" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="MaxRadius" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+							<element>
+								<attribute name="Min Size" value="0 16" />
+								<attribute name="Max Size" value="2147483647 16" />
+								<attribute name="Pivot" value="0 0" />
+								<attribute name="Layout Mode" value="Horizontal" />
+								<attribute name="Layout Spacing" value="10" />
+								<element type="Text" style="EditorAttributeText">
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Text" value="Max Radius Variance" />
+								</element>
+								<element>
+									<attribute name="Min Size" value="0 16" />
+									<attribute name="Max Size" value="2147483647 16" />
+									<attribute name="Pivot" value="0 0" />
+									<attribute name="Layout Mode" value="Horizontal" />
+									<attribute name="Layout Spacing" value="1" />
+									<element type="LineEdit">
+										<attribute name="Name" value="MaxRadiusVariance" />
+										<element type="Text" internal="true" style="none" />
+										<element type="BorderImage" internal="true" style="none" />
+									</element>
+								</element>
+							</element>
+						</element>
+					</element>
+				</element>
+			</element>
+			<element type="BorderImage" style="EditorDivider" />
+			<element>
+				<attribute name="Name" value="ButtonContainer" />
+				<attribute name="Min Size" value="0 16" />
+				<attribute name="Max Size" value="2147483647 16" />
+				<attribute name="Pivot" value="0 0" />
+				<attribute name="Layout Mode" value="Horizontal" />
+				<attribute name="Layout Spacing" value="4" />
+				<element type="Button">
+					<attribute name="Name" value="NewButton" />
+					<attribute name="Layout Mode" value="Horizontal" />
+					<attribute name="Layout Border" value="1 1 1 1" />
+					<element type="Text">
+						<attribute name="Text" value="New" />
+						<attribute name="Text Alignment" value="Center" />
+						<attribute name="Auto Localizable" value="true" />
+					</element>
+				</element>
+				<element type="Button">
+					<attribute name="Name" value="RevertButton" />
+					<attribute name="Layout Mode" value="Horizontal" />
+					<attribute name="Layout Border" value="1 1 1 1" />
+					<element type="Text">
+						<attribute name="Text" value="Revert" />
+						<attribute name="Text Alignment" value="Center" />
+						<attribute name="Auto Localizable" value="true" />
+					</element>
+				</element>
+				<element type="Button">
+					<attribute name="Name" value="SaveButton" />
+					<attribute name="Layout Mode" value="Horizontal" />
+					<attribute name="Layout Border" value="1 1 1 1" />
+					<element type="Text">
+						<attribute name="Text" value="Save" />
+						<attribute name="Text Alignment" value="Center" />
+						<attribute name="Auto Localizable" value="true" />
+					</element>
+				</element>
+				<element type="Button">
+					<attribute name="Name" value="SaveAsButton" />
+					<attribute name="Layout Mode" value="Horizontal" />
+					<attribute name="Layout Border" value="1 1 1 1" />
+					<element type="Text">
+						<attribute name="Text" value="Save as" />
+						<attribute name="Text Alignment" value="Center" />
+						<attribute name="Auto Localizable" value="true" />
+					</element>
+				</element>
+			</element>
+		</element>
+	</element>
+</element>


### PR DESCRIPTION
Adds a copy of the 3D particle editor, but configured for 2D.
I also added some extra methods for ParticleEffect2D and ParticleEmitter2D (and their bindings), to make some editor features easier/possible, like restarting the emitter when we change some specific attributes.