### PR TITLE
2d particle editor fix + fix swapped comment

### DIFF
--- a/Source/Urho3D/Urho2D/Urho2DEvents.h
+++ b/Source/Urho3D/Urho2D/Urho2DEvents.h
@@ -27,14 +27,14 @@
 namespace Urho3D
 {
 
-/// Emitting ParticleEmitter2D particles stopped.
+/// All ParticleEmitter2D particles have been removed.
 URHO3D_EVENT(E_PARTICLESEND, ParticlesEnd)
 {
     URHO3D_PARAM(P_NODE, Node);                    // Node pointer
     URHO3D_PARAM(P_EFFECT, Effect);                // ParticleEffect2D pointer
 }
 
-/// All ParticleEmitter2D particles have been removed.
+/// Emitting ParticleEmitter2D particles stopped.
 URHO3D_EVENT(E_PARTICLESDURATION, ParticlesDuration)
 {
     URHO3D_PARAM(P_NODE, Node);                    // Node pointer

--- a/bin/Data/Scripts/Editor/EditorParticle2D.as
+++ b/bin/Data/Scripts/Editor/EditorParticle2D.as
@@ -215,7 +215,7 @@ void UpdateParticleEffect2dWindow(float timeStep)
                 particle2dResetTimer = Max(particle2dResetTimer - timeStep, 0.0f);
                 if (particle2dResetTimer <= 0.0001f && particle2dLoopEmission)
                 {
-                    particleEffect2dEmitter.emitting = true;
+                    particleEffect2dEmitter.Reset();
                     particle2dResetTimer = 0.0f;
                 }
             }


### PR DESCRIPTION
Sometimes, 2d particles with a non-infinite duration would never restart, even with looping enabled. Calling Reset directly, like it's done with the 3d particles, seems to fix it.

I've also swapped the comments for the E_PARTICLESEND and E_PARTICLESDURATION events, because it's ParticlesEnd that's called when all particles from the emitter have "ended", not ParticleDuration.