### PR TITLE
Add autoremove to particleEmitter2d

### DIFF
--- a/Source/Urho3D/AngelScript/Generated_Members.h
+++ b/Source/Urho3D/AngelScript/Generated_Members.h
@@ -25104,6 +25104,10 @@ template <class T> void RegisterMembers_ParticleEmitter2D(asIScriptEngine* engin
 {
     RegisterMembers_Drawable2D<T>(engine, className);
 
+    // AutoRemoveMode ParticleEmitter2D::GetAutoRemoveMode() const
+    engine->RegisterObjectMethod(className, "AutoRemoveMode GetAutoRemoveMode() const", AS_METHODPR(T, GetAutoRemoveMode, () const, AutoRemoveMode), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "AutoRemoveMode get_autoRemoveMode() const", AS_METHODPR(T, GetAutoRemoveMode, () const, AutoRemoveMode), AS_CALL_THISCALL);
+
     // BlendMode ParticleEmitter2D::GetBlendMode() const
     engine->RegisterObjectMethod(className, "BlendMode GetBlendMode() const", AS_METHODPR(T, GetBlendMode, () const, BlendMode), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "BlendMode get_blendMode() const", AS_METHODPR(T, GetBlendMode, () const, BlendMode), AS_CALL_THISCALL);
@@ -25137,6 +25141,10 @@ template <class T> void RegisterMembers_ParticleEmitter2D(asIScriptEngine* engin
 
     // void ParticleEmitter2D::ResetEmissionTimer()
     engine->RegisterObjectMethod(className, "void ResetEmissionTimer()", AS_METHODPR(T, ResetEmissionTimer, (), void), AS_CALL_THISCALL);
+
+    // void ParticleEmitter2D::SetAutoRemoveMode(AutoRemoveMode mode)
+    engine->RegisterObjectMethod(className, "void SetAutoRemoveMode(AutoRemoveMode)", AS_METHODPR(T, SetAutoRemoveMode, (AutoRemoveMode), void), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void set_autoRemoveMode(AutoRemoveMode)", AS_METHODPR(T, SetAutoRemoveMode, (AutoRemoveMode), void), AS_CALL_THISCALL);
 
     // void ParticleEmitter2D::SetBlendMode(BlendMode blendMode)
     engine->RegisterObjectMethod(className, "void SetBlendMode(BlendMode)", AS_METHODPR(T, SetBlendMode, (BlendMode), void), AS_CALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/Urho2D/ParticleEmitter2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Urho2D/ParticleEmitter2D.pkg
@@ -1,5 +1,8 @@
 $#include "Urho2D/ParticleEmitter2D.h"
 
+// The actual enum is defined in Scene/Component.pkg
+enum AutoRemoveMode {};
+
 class ParticleEmitter2D : public Drawable2D
 {
 public:
@@ -7,6 +10,7 @@ public:
     void SetSprite(Sprite2D* sprite);
     void SetBlendMode(BlendMode blendMode);
     void SetEmitting(bool emitting);
+    void SetAutoRemoveMode(AutoRemoveMode mode);
     void RemoveAllParticles();
     void Reset();
     void ResetEmissionTimer();
@@ -15,9 +19,11 @@ public:
     Sprite2D* GetSprite() const;
     BlendMode GetBlendMode() const;
     bool IsEmitting() const;
+    AutoRemoveMode GetAutoRemoveMode() const;
 
     tolua_property__get_set ParticleEffect2D* effect;
     tolua_property__get_set Sprite2D* sprite;
     tolua_property__get_set BlendMode blendMode;
     tolua_property__is_set bool emitting;
+    tolua_property__get_set AutoRemoveMode autoRemoveMode;
 };

--- a/Source/Urho3D/Urho2D/ParticleEmitter2D.cpp
+++ b/Source/Urho3D/Urho2D/ParticleEmitter2D.cpp
@@ -42,6 +42,8 @@ namespace Urho3D
 extern const char* URHO2D_CATEGORY;
 extern const char* blendModeNames[];
 
+extern const char* autoRemoveModeNames[];
+
 ParticleEmitter2D::ParticleEmitter2D(Context* context) :
     Drawable2D(context),
     blendMode_(BLEND_ADDALPHA),
@@ -50,7 +52,8 @@ ParticleEmitter2D::ParticleEmitter2D(Context* context) :
     emitParticleTime_(0.0f),
     boundingBoxMinPoint_(Vector3::ZERO),
     boundingBoxMaxPoint_(Vector3::ZERO),
-    emitting_(true)
+    emitting_(true),
+    autoRemove_(REMOVE_DISABLED)
 {
     sourceBatches_.Resize(1);
     sourceBatches_[0].owner_ = this;
@@ -70,6 +73,7 @@ void ParticleEmitter2D::RegisterObject(Context* context)
         AM_DEFAULT);
     URHO3D_ENUM_ACCESSOR_ATTRIBUTE("Blend Mode", GetBlendMode, SetBlendMode, BlendMode, blendModeNames, BLEND_ALPHA, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Is Emitting", IsEmitting, SetEmitting, bool, true, AM_DEFAULT);
+    URHO3D_ENUM_ATTRIBUTE("Autoremove Mode", autoRemove_, autoRemoveModeNames, REMOVE_DISABLED, AM_DEFAULT);
 }
 
 void ParticleEmitter2D::OnSetEnabled()
@@ -135,6 +139,12 @@ void ParticleEmitter2D::SetMaxParticles(unsigned maxParticles)
     sourceBatches_[0].vertices_.Reserve(maxParticles * 4);
 
     numParticles_ = Min(maxParticles, numParticles_);
+}
+
+void ParticleEmitter2D::SetAutoRemoveMode(AutoRemoveMode mode)
+{
+    autoRemove_ = mode;
+    MarkNetworkUpdate();
 }
 
 void ParticleEmitter2D::ResetEmissionTimer()
@@ -314,9 +324,13 @@ void ParticleEmitter2D::HandleScenePostUpdate(StringHash eventType, VariantMap& 
 
         if (self.Expired())
             return;
+
+        emitting = false;
     }
     if (hasParticles && numParticles_ == 0)
     {
+        // Make a weak pointer to self to check for destruction during event handling
+        WeakPtr<ParticleEmitter2D> self(this);
         using namespace ParticlesEnd;
 
         VariantMap& eventData = GetEventDataMap();
@@ -324,6 +338,15 @@ void ParticleEmitter2D::HandleScenePostUpdate(StringHash eventType, VariantMap& 
         eventData[P_EFFECT] = effect_;
 
         SendEvent(E_PARTICLESEND, eventData);      // All particles over
+
+        if(!emitting)
+        {
+            if (self.Expired())
+                return;
+
+            DoAutoRemove(autoRemove_);
+        }
+
     }
 }
 

--- a/Source/Urho3D/Urho2D/ParticleEmitter2D.h
+++ b/Source/Urho3D/Urho2D/ParticleEmitter2D.h
@@ -103,6 +103,9 @@ public:
     /// Set whether should be emitting. If the state was changed, also resets the emission period timer.
     /// @property
     void SetEmitting(bool enable);
+    /// Set to remove either the emitter component or its owner node from the scene automatically on particle effect completion. Disabled by default.
+    /// @property
+    void SetAutoRemoveMode(AutoRemoveMode mode);
     /// Reset the emission period timer.
     void ResetEmissionTimer();
     /// Sets time left of all current particles to zero.
@@ -135,6 +138,9 @@ public:
     /// Return whether is currently emitting.
     /// @property
     bool IsEmitting() const { return emitting_; }
+    /// Return automatic removal mode on particle effect completion.
+    /// @property
+    AutoRemoveMode GetAutoRemoveMode() const { return autoRemove_; }
 
 private:
     /// Handle scene being assigned.
@@ -176,6 +182,8 @@ private:
     Vector3 boundingBoxMinPoint_;
     /// Bounding box max point.
     Vector3 boundingBoxMaxPoint_;
+    /// Automatic removal mode.
+    AutoRemoveMode autoRemove_;
 };
 
 }


### PR DESCRIPTION
I felt the need to use this function from the 3d emitters, so here it is! 
Adds the "AutoRemoveMode" stuff (and its bindings) for 2d particle emitters.