### PR TITLE
Fix particle2d editor not opening on attribute inspector "edit" btn click

### DIFF
--- a/bin/Data/Scripts/Editor/AttributeEditor.as
+++ b/bin/Data/Scripts/Editor/AttributeEditor.as
@@ -1404,11 +1404,12 @@ void EditResource(StringHash eventType, VariantMap& eventData)
 
     if (resource !is null)
     {
-        // For now only Materials can be edited
         if (resource.typeName == "Material")
             EditMaterial(cast<Material>(resource));
         else if (resource.typeName == "ParticleEffect")
             EditParticleEffect(cast<ParticleEffect>(resource));
+        else if (resource.typeName == "ParticleEffect2D")
+            EditParticleEffect2d(cast<ParticleEffect2D>(resource));
     }
 }
 


### PR DESCRIPTION
The "edit" btn was appearing for particleEffect2d attributes, but wasn't doing anything... this PR makes the btn open the particle2d editor correctly